### PR TITLE
ameshコマンドの後ろに文章をつけても反応しないようにする

### DIFF
--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -54,7 +54,7 @@ def totuzensi(message):
     msg = '\n```' + word + '```'
     message.send(msg)
 
-@respond_to('^amesh')
+@respond_to('^amesh$')
 def amesh(message):
     user = message.user['name']
     channel = message.channel._body['name']


### PR DESCRIPTION
`@hato amesh 大阪` のようにameshコマンドの後ろに文章をつけても反応しないようにします。