### PR TITLE
dotenvを使うことでローカルでの環境構築を手軽にする

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .vscode/
 slackbot_settings.py
 __pycache__/
+.env

--- a/README.md
+++ b/README.md
@@ -15,9 +15,9 @@ Slackで動くbotです。
 - Python3が動く環境
 
 ## 初期設定
+1. `.env` を作成し、SLackのAPI Tokenを記述します。
+    ```
+    SLACKBOT_API_TOKEN=hogehoge
+    ```
 
-1. 環境変数 `SLACKBOT_API_TOKEN` にSlackのAPI Tokenを設定します。
-```
-export SLACKBOT_API_TOKEN=hogehoge
-```
 2. `python3 ./run.py` します。

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Slackで動くbotです。
 - Python3が動く環境
 
 ## 初期設定
-1. `.env` を作成し、SLackのAPI Tokenを記述します。
+1. `.env` を作成し、SlackのAPI Tokenを記述します。
     ```
     SLACKBOT_API_TOKEN=hogehoge
     ```

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -5,12 +5,15 @@ from slackbot.bot import default_reply  # 該当する応答がない場合に�
 from slacker import Slacker
 import unicodedata
 import os
+from dotenv import load_dotenv, find_dotenv
 from logging import getLogger
 from library.weather import get_city_id_from_city_name
 from library.weather import get_weather
 from library.amesh import get_map
 from PIL import Image
 from datetime import datetime
+
+load_dotenv(find_dotenv())
 
 logger = getLogger(__name__)
 VERSION = "0.1.2"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 Pillow==6.2.0
 pytz==2019.2
 slackbot==0.5.4
+python-dotenv==0.10.4


### PR DESCRIPTION
ローカルで実行する場合、これまではSlackのAPI Tokenを毎回環境変数としてセットする必要がありましたが、dotenvを用いることで手順を簡略化します。