### PR TITLE
READMEの初期設定の記述を.envを使ったものに修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Slackで動くbotです。
 
 ## 初期設定
 
-1. 環境変数 `SLACKBOT_API_TOKEN` にSlackのAPI Tokenを設定します。
-```
-export SLACKBOT_API_TOKEN=hogehoge
-```
+1. `.env` ファイルを作成し、SlackのAPI Tokenを記述します。
+    ```.env
+    SLACKBOT_API_TOKEN=hogehoge
+    ```
 2. `python3 ./run.py` します。


### PR DESCRIPTION
https://github.com/nakkaa/hato-bot/commit/44998a20d103c07427562b12c21a8eae68b29a95 をREADMEに反映します。