### PR TITLE
Dependabot導入

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -1,0 +1,8 @@
+version: 1
+update_configs:
+  - package_manager: "python"
+    directory: "/"
+    update_schedule: "live"
+    allowed_updates:
+      - match:
+          update_type: "security"


### PR DESCRIPTION
https://app.dependabot.com/ を導入し、セキュリティアップデートを行うPRが随時投げられるようにします。
導入するには、このPRをマージ後、 @nakkaa の方でDependabotの実行対象としてこのリポジトリを追加する必要があります。