### PR TITLE
pg8000をverupすると動かない問題を解消

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ pytz = "==2020.1"
 requests = "==2.23.0"
 slackbot = "==0.5.6"
 Pillow = ">=7.1.2"
-pg8000 = "==1.13.2"
+pg8000 = "==1.15.2"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bfd4752003a733e3d24b72b304d44b6acee787e98096bb8b4f8d8df5dd34f0f7"
+            "sha256": "05183c9cefef53ffec3f30729c4619a1b217ff5519a739594b3d0cd449ef22ff"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -39,11 +39,11 @@
         },
         "pg8000": {
             "hashes": [
-                "sha256:e4c2b173178ba41bba19366b9cdeced91fecec2caf31c7ece719138633213cca",
-                "sha256:eebcb4176a7e407987e525a07454882f611985e0becb2b73f76efb93bbdc0aab"
+                "sha256:2bfdd03c2623302af655ef089a958ff329b2035c9d9aea406b5e4dac9c007524",
+                "sha256:eb42ba62fbc048c91d5cf1ac729e0ea4ee329cc526bddafed4e7a8aa6b57fbbb"
             ],
             "index": "pypi",
-            "version": "==1.13.2"
+            "version": "==1.15.2"
         },
         "pillow": {
             "hashes": [
@@ -99,10 +99,10 @@
         },
         "scramp": {
             "hashes": [
-                "sha256:475aa6296deb2737b86e9df9098e8eca0f30c8ad1cc0a8adadb99ef012a5ceba",
-                "sha256:e09d2a9be5adeb94cbeb56fc54a61fc5f5b6e140e679b2b60d1f7a8d6478d906"
+                "sha256:a2c740624642de84f77327da8f56b2f030c5afd10deccaedbb8eb6108a66dfc1",
+                "sha256:b57eb0ae2f9240b15b5d0dab2ea8e40b43eef13ac66d3f627a79ef85a6da0927"
             ],
-            "version": "==1.1.0"
+            "version": "==1.1.1"
         },
         "six": {
             "hashes": [
@@ -197,10 +197,10 @@
         },
         "pycodestyle": {
             "hashes": [
-                "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56",
-                "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"
+                "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367",
+                "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"
             ],
-            "version": "==2.5.0"
+            "version": "==2.6.0"
         },
         "pylint": {
             "hashes": [
@@ -223,6 +223,33 @@
                 "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"
             ],
             "version": "==0.10.0"
+        },
+        "typed-ast": {
+            "hashes": [
+                "sha256:0666aa36131496aed8f7be0410ff974562ab7eeac11ef351def9ea6fa28f6355",
+                "sha256:0c2c07682d61a629b68433afb159376e24e5b2fd4641d35424e462169c0a7919",
+                "sha256:249862707802d40f7f29f6e1aad8d84b5aa9e44552d2cc17384b209f091276aa",
+                "sha256:24995c843eb0ad11a4527b026b4dde3da70e1f2d8806c99b7b4a7cf491612652",
+                "sha256:269151951236b0f9a6f04015a9004084a5ab0d5f19b57de779f908621e7d8b75",
+                "sha256:4083861b0aa07990b619bd7ddc365eb7fa4b817e99cf5f8d9cf21a42780f6e01",
+                "sha256:498b0f36cc7054c1fead3d7fc59d2150f4d5c6c56ba7fb150c013fbc683a8d2d",
+                "sha256:4e3e5da80ccbebfff202a67bf900d081906c358ccc3d5e3c8aea42fdfdfd51c1",
+                "sha256:6daac9731f172c2a22ade6ed0c00197ee7cc1221aa84cfdf9c31defeb059a907",
+                "sha256:715ff2f2df46121071622063fc7543d9b1fd19ebfc4f5c8895af64a77a8c852c",
+                "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3",
+                "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b",
+                "sha256:8ce678dbaf790dbdb3eba24056d5364fb45944f33553dd5869b7580cdbb83614",
+                "sha256:aaee9905aee35ba5905cfb3c62f3e83b3bec7b39413f0a7f19be4e547ea01ebb",
+                "sha256:bcd3b13b56ea479b3650b82cabd6b5343a625b0ced5429e4ccad28a8973f301b",
+                "sha256:c9e348e02e4d2b4a8b2eedb48210430658df6951fa484e59de33ff773fbd4b41",
+                "sha256:d205b1b46085271b4e15f670058ce182bd1199e56b317bf2ec004b6a44f911f6",
+                "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34",
+                "sha256:d5d33e9e7af3b34a40dc05f498939f0ebf187f07c385fd58d591c533ad8562fe",
+                "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4",
+                "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
+            ],
+            "markers": "implementation_name == 'cpython' and python_version < '3.8'",
+            "version": "==1.4.1"
         },
         "wrapt": {
             "hashes": [

--- a/create_env.py
+++ b/create_env.py
@@ -16,11 +16,12 @@ class CreateEnvDatabase:
                 user=conf.DB_USER,
                 password=conf.DB_PASSWORD,
                 port=conf.DB_PORT,
-                ssl=conf.DB_SSL,
+                ssl_context=conf.DB_SSL,
                 database=conf.DB_NAME
             )
         except:
             print('Can not connect to database.')
+            raise
 
     def __enter__(self):
         return self

--- a/library/labotter.py
+++ b/library/labotter.py
@@ -12,7 +12,7 @@ class LabotterDatabase:
                 user=conf.DB_USER,
                 password=conf.DB_PASSWORD,
                 port=conf.DB_PORT,
-                ssl=conf.DB_SSL,
+                ssl_context=conf.DB_SSL,
                 database=conf.DB_NAME
             )
         except:

--- a/library/vocabularydb.py
+++ b/library/vocabularydb.py
@@ -11,7 +11,7 @@ class VocabularyDatabase:
                 user=conf.DB_USER,
                 password=conf.DB_PASSWORD,
                 port=conf.DB_PORT,
-                ssl=conf.DB_SSL,
+                ssl_context=conf.DB_SSL,
                 database=conf.DB_NAME
             )
         except:

--- a/slackbot_settings.py
+++ b/slackbot_settings.py
@@ -17,7 +17,7 @@ DB_PORT = db_auth.port
 DB_NAME = db_auth.path[1:]
 
 # DB_NAMEが空の場合はSSLを無効にする(for Develop)。Herokuの場合はTrue。
-DB_SSL = bool(db_auth.path[1:])
+DB_SSL = True if db_auth.path[1:] != '' else None
 
 # Yahoo APIを用いるためのTokenを指定する。
 YAHOO_API_TOKEN = str(os.environ['YAHOO_API_TOKEN'])


### PR DESCRIPTION
pg8000のSSL周りの記述を修正し、バージョンアップしても動作するよう修正します。