### PR TITLE
import文をline-too-longの対象から除外

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -445,7 +445,7 @@ signature-mutators=
 expected-line-ending-format=
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*((# )?<?https?://\S+>?|(from)? .* import .*)$
+ignore-long-lines=^\s*((# )?<?https?://\S+>?|(from .* )?import .*)$
 
 # Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4

--- a/.pylintrc
+++ b/.pylintrc
@@ -445,7 +445,7 @@ signature-mutators=
 expected-line-ending-format=
 
 # Regexp for a line that is allowed to be longer than the limit.
-ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+ignore-long-lines=^\s*((# )?<?https?://\S+>?|(from)? .* import .*)$
 
 # Number of spaces of indent required inside a hanging or continued line.
 indent-after-paren=4


### PR DESCRIPTION
import文をpylintの `line-too-long` の対象から除外します。