### PR TITLE
pr-lintの結果が空ならばコメントしない

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -181,6 +181,7 @@ jobs:
         continue-on-error: true
       # lint結果をコメントに残す
       - name: Lint Comment
+        if: steps.lint.outputs.result != ''
         uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
`pr-lint` の結果が空の場合、PRにコメントしないようにします。

<例>
* `pr-lint` の結果が空になる: https://github.com/nakkaa/hato-bot/pull/94
* `pr-lint` の結果が空にならない: https://github.com/nakkaa/hato-bot/pull/96