### PR TITLE
[マージしない] pr-lintの結果が空になる例

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -181,6 +181,7 @@ jobs:
         continue-on-error: true
       # lint結果をコメントに残す
       - name: Lint Comment
+        if: steps.lint.outputs.result != ''
         uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
https://github.com/nakkaa/hato-bot/pull/93 の `pr-lint` の結果が空になる例です。