### PR TITLE
DB関連の処理を共通化

### DIFF
--- a/library/database.py
+++ b/library/database.py
@@ -1,0 +1,31 @@
+"""
+DBを操作するためのベースクラス
+"""
+
+import pg8000
+
+import slackbot_settings as conf
+
+
+class Database:
+    """DBを操作するためのベースクラス"""
+
+    def __init__(self):
+        try:
+            pg8000.paramstyle = 'qmark'
+            self.conn = pg8000.connect(
+                host=conf.DB_HOST,
+                user=conf.DB_USER,
+                password=conf.DB_PASSWORD,
+                port=conf.DB_PORT,
+                ssl_context=conf.DB_SSL,
+                database=conf.DB_NAME
+            )
+        except pg8000.Error:
+            print('Can not connect to database.')
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        self.conn.close()

--- a/library/labotter.py
+++ b/library/labotter.py
@@ -6,30 +6,13 @@ import datetime
 from typing import Tuple
 import pg8000
 
-import slackbot_settings as conf
+from library.database import Database
 
 
-class LabotterDatabase:
+class LabotterDatabase(Database):
     """
     らぼったーのDB処理
     """
-
-    def __init__(self):
-        try:
-            pg8000.paramstyle = 'qmark'
-            self.conn = pg8000.connect(
-                host=conf.DB_HOST,
-                user=conf.DB_USER,
-                password=conf.DB_PASSWORD,
-                port=conf.DB_PORT,
-                ssl_context=conf.DB_SSL,
-                database=conf.DB_NAME
-            )
-        except pg8000.Error:
-            print('Can not connect to database.')
-
-    def __enter__(self):
-        return self
 
     def check_exist_user_name(self, user_name: str) -> bool:
         """
@@ -120,9 +103,6 @@ class LabotterDatabase:
                 "SELECT lab_in, min_sum FROM labotter WHERE user_name = ?;", (user_name,))
             labo_in_time, min_sum = cursor.fetchone()
         return labo_in_time, min_sum
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.conn.close()
 
 
 def labo_in(user_name: str) -> Tuple[bool, str]:

--- a/library/vocabularydb.py
+++ b/library/vocabularydb.py
@@ -3,28 +3,12 @@
 """
 
 import pg8000
-import slackbot_settings as conf
+
+from library.database import Database
 
 
-class VocabularyDatabase:
+class VocabularyDatabase(Database):
     """パワーワードを扱うDBを操作するためのクラス"""
-
-    def __init__(self):
-        try:
-            pg8000.paramstyle = 'qmark'
-            self.conn = pg8000.connect(
-                host=conf.DB_HOST,
-                user=conf.DB_USER,
-                password=conf.DB_PASSWORD,
-                port=conf.DB_PORT,
-                ssl_context=conf.DB_SSL,
-                database=conf.DB_NAME
-            )
-        except pg8000.Error:
-            print('Can not connect to database.')
-
-    def __enter__(self):
-        return self
 
     def get_word_list(self):
         """パワーワードの一覧をDBから取得する"""
@@ -71,9 +55,6 @@ class VocabularyDatabase:
                 self.conn.commit()
             except pg8000.Error:
                 print('Can not execute sql(delete).')
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.conn.close()
 
 
 def get_vocabularys():


### PR DESCRIPTION
https://github.com/nakkaa/hato-bot/pull/129#issuecomment-640013771

```
************* Module tests.test_slackbot_settings
tests/test_slackbot_settings.py:1:0: R0801: Similar lines in 2 files
==library.labotter:16
==library.vocabularydb:11
    def __init__(self):
        try:
            pg8000.paramstyle = 'qmark'
            self.conn = pg8000.connect(
                host=conf.DB_HOST,
                user=conf.DB_USER,
                password=conf.DB_PASSWORD,
                port=conf.DB_PORT,
                ssl_context=conf.DB_SSL,
                database=conf.DB_NAME
            )
        except pg8000.Error:
            print('Can not connect to database.')

    def __enter__(self):
        return self
 (duplicate-code)
tests/test_slackbot_settings.py:1:0: R0801: Similar lines in 3 files
==create_env:14
==library.labotter:16
==library.vocabularydb:11
    def __init__(self):
        try:
            pg8000.paramstyle = 'qmark'
            self.conn = pg8000.connect(
                host=conf.DB_HOST,
                user=conf.DB_USER,
                password=conf.DB_PASSWORD,
                port=conf.DB_PORT,
                ssl_context=conf.DB_SSL,
                database=conf.DB_NAME
            ) (duplicate-code)

-----------------------------------
Your code has been rated at 9.96/10
```

LabotterDatabaseとVocabularyDatabaseの共通部分を切り出したクラスを作ります。