### PR TITLE
DB関連の処理を共通化

### DIFF
--- a/create_env.py
+++ b/create_env.py
@@ -2,33 +2,14 @@
 初回動かす必要のあるスクリプト
 """
 
-import pg8000
-import slackbot_settings as conf
+from library.database import Database
 
 
-class CreateEnvDatabase:
+class CreateEnvDatabase(Database):
     """
     DBのテーブル作成用スクリプト
     初回環境構築時のみ必要
     """
-
-    def __init__(self):
-        try:
-            pg8000.paramstyle = 'qmark'
-            self.conn = pg8000.connect(
-                host=conf.DB_HOST,
-                user=conf.DB_USER,
-                password=conf.DB_PASSWORD,
-                port=conf.DB_PORT,
-                ssl_context=conf.DB_SSL,
-                database=conf.DB_NAME
-            )
-        except:
-            print('Can not connect to database.')
-            raise
-
-    def __enter__(self):
-        return self
 
     def execute_sql(self, sql: str) -> None:
         """SQLを実行する"""
@@ -41,9 +22,6 @@ class CreateEnvDatabase:
             except Exception as _e:
                 print('Can not execute sql(create_table).')
                 raise _e
-
-    def __exit__(self, exc_type, exc_value, traceback):
-        self.conn.close()
 
 
 def create_table() -> None:

--- a/create_env.py
+++ b/create_env.py
@@ -5,29 +5,10 @@
 from library.database import Database
 
 
-class CreateEnvDatabase(Database):
-    """
-    DBのテーブル作成用スクリプト
-    初回環境構築時のみ必要
-    """
-
-    def execute_sql(self, sql: str) -> None:
-        """SQLを実行する"""
-
-        with self.conn.cursor() as cursor:
-            try:
-                cursor.execute(sql)
-                self.conn.commit()
-                print('Create table. {}'.format(sql))
-            except Exception as _e:
-                print('Can not execute sql(create_table).')
-                raise _e
-
-
 def create_table() -> None:
     """テーブルを作成する"""
 
-    with CreateEnvDatabase() as _db, open('setup/pgsql-init/02_init.sql') as init_sql:
+    with Database() as _db, open('setup/pgsql-init/02_init.sql') as init_sql:
         for line in init_sql.readlines():
             _db.execute_sql(line)
 

--- a/library/database.py
+++ b/library/database.py
@@ -29,3 +29,15 @@ class Database:
 
     def __exit__(self, exc_type, exc_value, traceback):
         self.conn.close()
+
+    def execute_sql(self, sql: str) -> None:
+        """SQLを実行する"""
+
+        with self.conn.cursor() as cursor:
+            try:
+                cursor.execute(sql)
+                self.conn.commit()
+                print('Execute: {}'.format(sql))
+            except Exception as _e:
+                print('Can not execute sql(create_table).')
+                raise _e


### PR DESCRIPTION
https://github.com/nakkaa/hato-bot/pull/129#issuecomment-640015624

```
************* Module tests.test_slackbot_settings
tests/test_slackbot_settings.py:1:0: R0801: Similar lines in 2 files
==create_env:14
==library.database:12
    def __init__(self):
        try:
            pg8000.paramstyle = 'qmark'
            self.conn = pg8000.connect(
                host=conf.DB_HOST,
                user=conf.DB_USER,
                password=conf.DB_PASSWORD,
                port=conf.DB_PORT,
                ssl_context=conf.DB_SSL,
                database=conf.DB_NAME
            ) (duplicate-code)

-----------------------------------
Your code has been rated at 9.98/10
```

https://github.com/nakkaa/hato-bot/pull/130 で共通化しきれていなかった部分を共通化します。