### PR TITLE
テーブルを作成する手順を削除

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,6 @@
     cd ..
     ```
 
-5. `pipenv run python ./create_env.py` を実行しPostgreSQLにテーブルを作成します。
-
 6. `pipenv run python ./run.py` を実行します。
 
 ## 補足


### PR DESCRIPTION
開発環境の場合、postgresqlのDockerコンテナを立ち上げれば自動的にテーブル作成も行われるため、テーブルを作成する手順をREADMEから削除します。