### PR TITLE
lintに指摘されてCIが落ちる場合 (fork先からのPRの場合、formatの修正点やlint結果をCIの出力として出す) #136

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -45,8 +45,12 @@ jobs:
         id: format
         run: |
           pipenv run autopep8 --exit-code --in-place --recursive .
-          git diff
         continue-on-error: true
+      # 差分があったときは差分を出力する
+      - name: Show diff
+        if: steps.format.outcome == 'failure'
+        run: |
+          git diff
       # 差分があったときは、コミットを作りpushする
       - name: Push
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure'

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -198,7 +198,7 @@ jobs:
         continue-on-error: true
       # lint結果をコメントに残す
       - name: Lint Comment
-        if: steps.lint.outputs.result != ''
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != ''
         uses: actions/github-script@0.9.0
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -194,6 +194,7 @@ jobs:
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::$result"
+          echo "$result"
           true
         continue-on-error: true
       # lint結果をコメントに残す

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,19 +46,18 @@ jobs:
         run: |
           pipenv run autopep8 --exit-code --in-place --recursive .
         continue-on-error: true
-      # fork先からのPRで差分があったときは、差分を出力する
-      - name: Push
-        if: github.event.pull_request.head.repo.full_name != github.repository && steps.format.outcome == 'failure'
+      # 差分を出力する
+      - name: Show diff
+        if: steps.format.outcome == 'failure'
         run: |
           git add -u
           git diff
-      # 元のリポジトリで差分があったときは、コミットを作りpushする
+      # 差分があったときは、コミットを作りpushする
       - name: Push
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure'
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
-          git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-format-${{github.event.pull_request.head.ref}}
       # pushしたブランチでPRを作る

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,7 +46,13 @@ jobs:
         run: |
           pipenv run autopep8 --exit-code --in-place --recursive .
         continue-on-error: true
-      # 差分があったときは、コミットを作りpushする
+      # fork先からのPRで差分があったときは、差分を出力する
+      - name: Push
+        if: github.event.pull_request.head.repo.full_name != github.repository && steps.format.outcome == 'failure'
+        run: |
+          git add -u
+          git diff
+      # 元のリポジトリで差分があったときは、コミットを作りpushする
       - name: Push
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure'
         run: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -194,7 +194,7 @@ jobs:
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::$result"
-          echo "$result"
+          echo -e "$result"
           true
         continue-on-error: true
       # lint結果をコメントに残す

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -196,7 +196,7 @@ jobs:
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::$result"
           true
-        continue-on-error: true
+        continue-on-error: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
       # lint結果をコメントに残す
       - name: Lint Comment
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.lint.outputs.result != ''

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -48,7 +48,7 @@ jobs:
         continue-on-error: true
       # 差分があったときは、コミットを作りpushする
       - name: Push
-        if: steps.format.outcome == 'failure'
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure'
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
@@ -58,7 +58,7 @@ jobs:
       # pushしたブランチでPRを作る
       - name: Create PullRequest
         uses: actions/github-script@0.9.0
-        if: steps.format.outcome == 'failure'
+        if: github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure'
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -45,19 +45,15 @@ jobs:
         id: format
         run: |
           pipenv run autopep8 --exit-code --in-place --recursive .
-        continue-on-error: true
-      # 差分を出力する
-      - name: Show diff
-        if: steps.format.outcome == 'failure'
-        run: |
-          git add -u
           git diff
+        continue-on-error: true
       # 差分があったときは、コミットを作りpushする
       - name: Push
         if: github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure'
         run: |
           git config user.name "hatohakaraage"
           git config user.email "hatohakaraage@example.com"
+          git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git HEAD:refs/heads/fix-format-${{github.event.pull_request.head.ref}}
       # pushしたブランチでPRを作る

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -190,11 +190,11 @@ jobs:
         id: lint
         run: |
           result=$(pipenv run pylint --rcfile=./.pylintrc $(find . -iname "*.py") 2>&1) || true
+          echo "$result"
           result="${result//'%'/'%25'}"
           result="${result//$'\n'/'%0A'}"
           result="${result//$'\r'/'%0D'}"
           echo "::set-output name=result::$result"
-          echo -e "$result"
           true
         continue-on-error: true
       # lint結果をコメントに残す

--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -21,8 +21,7 @@ logger = getLogger(__name__)
 VERSION = "1.0.4"
 
 
-def respond_to_with_space(matchstr: str, flags: int = 0) -> \
-        Callable[[Callable[[str], None]], Callable[[str], None]]:
+def respond_to_with_space(matchstr: str, flags: int = 0) -> Callable[[Callable[[str], None]], Callable[[str], None]]:
     """スペースを削除する"""
 
     space = ' '


### PR DESCRIPTION
https://github.com/nakkaa/hato-bot/pull/136 でlintの指摘事項があった場合のPRです。
CIが失敗するのが正常な動作です。