### PR TITLE
format修正のPRが既に作成されていたら作成しないようにする

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -74,6 +74,7 @@ jobs:
               head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}"
             })
+            console.log(prs)
             if(!prs) {
               github.pulls.create({
                 owner: context.repo.owner,

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,26 +67,24 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            const prs = github.pulls.list({
+            github.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
               state: "open",
               head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}"
+            }).then(res => {
+              if (res.data.length === 0) {
+                github.pulls.create({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
+                  body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
+                  head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
+                  base: "${{github.event.pull_request.head.ref}}"
+                })
+              }
             })
-            prs.then((res)=>{
-              console.log(res)
-            })
-            if(!prs) {
-              github.pulls.create({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
-                body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
-                head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
-                base: "${{github.event.pull_request.head.ref}}"
-              })
-            }
       - name: Exit
         if: steps.format.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,14 +67,23 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.pulls.create({
+            const prs = github.pulls.list({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
-              body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
+              state: "open",
               head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}"
             })
+            if(!prs) {
+              github.pulls.create({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
+                body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
+                head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
+                base: "${{github.event.pull_request.head.ref}}"
+              })
+            }
       - name: Exit
         if: steps.format.outcome == 'failure'
         run: exit 1

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -67,21 +67,21 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            github.pulls.list({
+            const common_params = {
               owner: context.repo.owner,
               repo: context.repo.repo,
-              state: "open",
               head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}"
+            }
+            github.pulls.list({
+              state: "open",
+              ...common_params
             }).then(res => {
               if (res.data.length === 0) {
                 github.pulls.create({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
                   title: "formatが間違ってたので直してあげたよ！PRをマージしてね！ #${{github.event.pull_request.number}}",
                   body: "鳩の唐揚げおいしい！😋😋😋 #${{github.event.pull_request.number}}",
-                  head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
-                  base: "${{github.event.pull_request.head.ref}}"
+                  ...common_params
                 })
               }
             })

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -74,7 +74,9 @@ jobs:
               head: "refs/heads/fix-format-${{github.event.pull_request.head.ref}}",
               base: "${{github.event.pull_request.head.ref}}"
             })
-            console.log(prs)
+            prs.then((res)=>{
+              console.log(res)
+            })
             if(!prs) {
               github.pulls.create({
                 owner: context.repo.owner,


### PR DESCRIPTION
format修正のPRが既にある状態でformat修正の必要があるコミットを追加すると、再度format修正のPRを投げようとしてCIが落ちます。
従って、既にformat修正のPRがある場合はPRを作成しないようにします。
なお、修正箇所はNode.jsで記述されています。