### PR TITLE
CIによるコミットをGitHub Actionsによるコミット扱いにする

### DIFF
--- a/.github/workflows/pr-check-yarn.yml
+++ b/.github/workflows/pr-check-yarn.yml
@@ -38,8 +38,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/yarn-${HEAD_REF}"

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -38,8 +38,8 @@ jobs:
         if: ${{ steps.show_diff.outputs.diff != '' }}
         working-directory: sudden-death
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -A
           git commit -m "鳩は唐揚げ！(hato-botのCIを反映するよ！)"
           echo "${{secrets.SUDDEN_DEATH_CI_PRIVATE_KEY}}" > deploy_key.pem

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -70,8 +70,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.format.outcome == 'failure' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-format-${HEAD_REF}"

--- a/.github/workflows/pr-textlint.yml
+++ b/.github/workflows/pr-textlint.yml
@@ -138,8 +138,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ steps.show_diff.outputs.diff != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add -u
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-text-${HEAD_REF}"

--- a/.github/workflows/pr-update-pre-commit-config-hato-bot.yml
+++ b/.github/workflows/pr-update-pre-commit-config-hato-bot.yml
@@ -55,8 +55,8 @@ jobs:
           HEAD_REF: ${{github.event.pull_request.head.ref}}
         if: ${{ github.event.pull_request.head.repo.full_name == github.repository && steps.diff.outputs.result != '' }}
         run: |
-          git config user.name "hatohakaraage"
-          git config user.email "hatohakaraage@example.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git add .pre-commit-config.yaml
           git commit -m "鳩は唐揚げ！(自動で直してあげたよ！)"
           git push -f https://${{github.actor}}:${{secrets.GITHUB_TOKEN}}@github.com/${{github.repository}}.git "HEAD:refs/heads/fix-version-pre-commit-config-${HEAD_REF}"


### PR DESCRIPTION
https://docs.github.com/ja/account-and-profile/setting-up-and-managing-your-github-user-account/managing-email-preferences/setting-your-commit-email-address

>GitHubアカウントを2017年7月18日以降に作成した場合、GitHubが提供するno-replyメールアドレスは7桁のID番号とユーザ名をID+username@users.noreply.github.comという形式にしたものになります。

https://api.github.com/users/github-actions[bot]

```json
{
  "login": "github-actions[bot]",
  "id": 41898282,
  ...
}
```

CIによるコミットのCommitterを `github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>` に変更することで、CIによるコミットをGitHub Actionsによるコミット扱いにしてみます。