### PR TITLE
hato-botイメージのマルチプラットフォーム対応

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,8 +41,8 @@ services:
       x-bake:
         platforms:
           - linux/amd64
+          - linux/arm64
     image: ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot:${TAG_NAME}
-    platform: linux/amd64
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
`hato-bot` のDockerイメージをARM64に対応させないとM1 Macでうまく動作しないので、マルチプラットフォーム対応させます。