### PR TITLE
電力: 表示できる使用率がない場合は取得できなかった旨を返す

### DIFF
--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -362,6 +362,11 @@ def electricity_demand(client: BaseClient):
     df_base = pd.read_csv(res_io, encoding="shift_jis", skiprows=12, index_col="TIME")
     df_percent = df_base[:24]["使用率(%)"].dropna().astype(int)
     latest_data = df_percent[df_percent > 0]
+
+    if latest_data.empty:
+        client.post("東京電力管内の電力使用率を取得できなかったっぽ......")
+        return
+
     client.post(
         f"東京電力管内の電力使用率をお知らせするっぽ！\n"
         f"{latest_data.index[-1]}時点 {latest_data[-1]}%"


### PR DESCRIPTION
電力使用率は日付が変わったばかりで実績値がない場合、表示できるデータがない状態となります。
このような場合はデータを取得できなかった旨を返すようにします。