### PR TITLE
docker-compose.ymlからplatform削除

### DIFF
--- a/build.docker-compose.yml
+++ b/build.docker-compose.yml
@@ -14,4 +14,3 @@ services:
         platforms:
           - linux/amd64
     image: ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/commit-hash:${TAG_NAME}
-    platform: linux/amd64

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,7 +42,6 @@ services:
         platforms:
           - linux/amd64
     image: ghcr.io/${REPOSITORY:-dev-hato/hato-bot}/hato-bot:${TAG_NAME}
-    platform: linux/amd64
     env_file:
       - .env
     restart: always


### PR DESCRIPTION
MacではARM64でビルドしたいので、 `docker-compose.yml` から `platform` を削除します。