### PR TITLE
sudden-death関連の依存関係修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ name = "hato-bot"
 version = "3.0.5"
 description = "愛嬌のあるBot"
 requires-python = "==3.13.1"
-dependencies = [ "python-dotenv==1.0.1", "requests==2.32.3", "Pillow>=7.1.2", "opencv-python==4.10.0.84", "pyperclip==1.9.0", "click==8.1.7", "slack-bolt==1.22.0", "slack-sdk==3.34.0", "gitpython==3.1.44", "pandas==2.2.3", "matplotlib==3.10.0", "openai==1.59.3", "discord.py==2.4.0", "misskey.py==4.1.0", "websockets==14.1", "flask==3.1.0", "markupsafe==3.0.2", "numpy==2.2.1", "emoji==2.14.0", "puremagic==1.28", "audioop-lts==0.2.1", "psycopg[binary,pool]==3.2.3", "sudden-death @ git+https://github.com/dev-hato/sudden-death@master",]
+dependencies = [ "python-dotenv==1.0.1", "requests==2.32.3", "Pillow>=7.1.2", "opencv-python==4.10.0.84", "slack-bolt==1.22.0", "slack-sdk==3.34.0", "gitpython==3.1.44", "pandas==2.2.3", "matplotlib==3.10.0", "openai==1.59.3", "discord.py==2.4.0", "misskey.py==4.1.0", "websockets==14.1", "flask==3.1.0", "markupsafe==3.0.2", "numpy==2.2.1", "emoji==2.14.0", "puremagic==1.28", "audioop-lts==0.2.1", "psycopg[binary,pool]==3.2.3", "sudden-death==0.0.1",]
 
 [dependency-groups]
 dev = [ "autopep8==2.3.1", "requests-mock==1.12.1", "pylint==3.3.3", "sqlfluff==3.3.0", "mypy==1.14.1", "flake8==7.1.1", "isort==5.13.2", "pre-commit==4.0.1", "importlib-metadata==8.5.0", "toml==0.10.2", "types-toml==0.10.8.20240310", "pyink==24.10.0",]
@@ -13,3 +13,5 @@ dev = [ "autopep8==2.3.1", "requests-mock==1.12.1", "pylint==3.3.3", "sqlfluff==
 name = "pypi"
 url = "https://pypi.org/simple"
 
+[tool.uv.sources]
+sudden-death = { git = "https://github.com/dev-hato/sudden-death", branch = "master" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,29 @@ name = "hato-bot"
 version = "3.0.5"
 description = "愛嬌のあるBot"
 requires-python = "==3.13.1"
-dependencies = [ "python-dotenv==1.0.1", "requests==2.32.3", "Pillow>=7.1.2", "opencv-python==4.10.0.84", "slack-bolt==1.22.0", "slack-sdk==3.34.0", "gitpython==3.1.44", "pandas==2.2.3", "matplotlib==3.10.0", "openai==1.59.3", "discord.py==2.4.0", "misskey.py==4.1.0", "websockets==14.1", "flask==3.1.0", "markupsafe==3.0.2", "numpy==2.2.1", "emoji==2.14.0", "puremagic==1.28", "audioop-lts==0.2.1", "psycopg[binary,pool]==3.2.3", "sudden-death==0.0.1",]
+dependencies = [
+ "python-dotenv==1.0.1",
+ "requests==2.32.3",
+ "Pillow>=7.1.2",
+ "opencv-python==4.10.0.84",
+ "slack-bolt==1.22.0",
+ "slack-sdk==3.34.0",
+ "gitpython==3.1.44",
+ "pandas==2.2.3",
+ "matplotlib==3.10.0",
+ "openai==1.59.3",
+ "discord.py==2.4.0",
+ "misskey.py==4.1.0",
+ "websockets==14.1",
+ "flask==3.1.0",
+ "markupsafe==3.0.2",
+ "numpy==2.2.1",
+ "emoji==2.14.0",
+ "puremagic==1.28",
+ "audioop-lts==0.2.1",
+ "psycopg[binary,pool]==3.2.3",
+ "sudden-death==0.0.1",
+]
 
 [dependency-groups]
 dev = [ "autopep8==2.3.1", "requests-mock==1.12.1", "pylint==3.3.3", "sqlfluff==3.3.0", "mypy==1.14.1", "flake8==7.1.1", "isort==5.13.2", "pre-commit==4.0.1", "importlib-metadata==8.5.0", "toml==0.10.2", "types-toml==0.10.8.20240310", "pyink==24.10.0",]

--- a/scripts/pr_format/pr_format/format.sh
+++ b/scripts/pr_format/pr_format/format.sh
@@ -6,6 +6,9 @@ tag_version="$(yq '.jobs.pr-super-lint.steps[-1].uses | line_comment' .github/wo
 pyink_version="$(docker run --rm --entrypoint '' "ghcr.io/${tag_name}-${tag_version}" /bin/sh -c 'pyink --version' | grep pyink | awk '{ print $2 }')"
 sed -i -e "s/pyink==.*\"/pyink==${pyink_version}\"/g" pyproject.toml
 uv sync --dev
+sudden_death_url="$(yq .tool.uv.sources.sudden-death.git pyproject.toml)"
+sudden_death_branch="$(yq .tool.uv.sources.sudden-death.branch pyproject.toml)"
+uv add "git+$sudden_death_url" --branch "$sudden_death_branch"
 uv tool run autopep8 --exit-code --in-place --recursive .
 uv tool run pyink --config .python-black .
 uv tool run isort --sp .isort.cfg .

--- a/uv.lock
+++ b/uv.lock
@@ -229,14 +229,14 @@ wheels = [
 
 [[package]]
 name = "click"
-version = "8.1.7"
+version = "8.1.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "colorama", marker = "sys_platform == 'win32'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/96/d3/f04c7bfcf5c1862a2a5b845c6b2b360488cf47af55dfa79c98f6a6bf98b5/click-8.1.7.tar.gz", hash = "sha256:ca9853ad459e787e2192211578cc907e7594e294c7ccc834310722b41b9ca6de", size = 336121 }
+sdist = { url = "https://files.pythonhosted.org/packages/b9/2e/0090cbf739cee7d23781ad4b89a9894a41538e4fcf4c31dcdd705b78eb8b/click-8.1.8.tar.gz", hash = "sha256:ed53c9d8990d83c2a27deae68e4ee337473f6330c040a31d4225c9574d16096a", size = 226593 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/00/2e/d53fa4befbf2cfa713304affc7ca780ce4fc1fd8710527771b58311a3229/click-8.1.7-py3-none-any.whl", hash = "sha256:ae74fb96c20a0277a1d615f1e4d73c8414f5a98db8b799a7931d1582f3390c28", size = 97941 },
+    { url = "https://files.pythonhosted.org/packages/7e/d4/7ebdbd03970677812aac39c869717059dbb71a4cfc033ca6e5221787892c/click-8.1.8-py3-none-any.whl", hash = "sha256:63c132bbbed01578a06712a2d1f497bb62d9c1c0d329b7903a866228027263b2", size = 98188 },
 ]
 
 [[package]]
@@ -470,7 +470,6 @@ version = "3.0.5"
 source = { virtual = "." }
 dependencies = [
     { name = "audioop-lts" },
-    { name = "click" },
     { name = "discord-py" },
     { name = "emoji" },
     { name = "flask" },
@@ -485,7 +484,6 @@ dependencies = [
     { name = "pillow" },
     { name = "psycopg", extra = ["binary", "pool"] },
     { name = "puremagic" },
-    { name = "pyperclip" },
     { name = "python-dotenv" },
     { name = "requests" },
     { name = "slack-bolt" },
@@ -513,7 +511,6 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "audioop-lts", specifier = "==0.2.1" },
-    { name = "click", specifier = "==8.1.7" },
     { name = "discord-py", specifier = "==2.4.0" },
     { name = "emoji", specifier = "==2.14.0" },
     { name = "flask", specifier = "==3.1.0" },
@@ -528,12 +525,11 @@ requires-dist = [
     { name = "pillow", specifier = ">=7.1.2" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = "==3.2.3" },
     { name = "puremagic", specifier = "==1.28" },
-    { name = "pyperclip", specifier = "==1.9.0" },
     { name = "python-dotenv", specifier = "==1.0.1" },
     { name = "requests", specifier = "==2.32.3" },
     { name = "slack-bolt", specifier = "==1.22.0" },
     { name = "slack-sdk", specifier = "==3.34.0" },
-    { name = "sudden-death", git = "https://github.com/dev-hato/sudden-death?rev=master" },
+    { name = "sudden-death", git = "https://github.com/dev-hato/sudden-death?branch=replace_setup_py" },
     { name = "websockets", specifier = "==14.1" },
 ]
 
@@ -1393,7 +1389,7 @@ wheels = [
 [[package]]
 name = "sudden-death"
 version = "0.0.1"
-source = { git = "https://github.com/dev-hato/sudden-death?rev=master#53f103e9dbd831870e41a93eb547b3eb8cf869f6" }
+source = { git = "https://github.com/dev-hato/sudden-death?branch=replace_setup_py#76e5e2c7935bcc9fe1b59c21a92dbbe2a656af49" }
 dependencies = [
     { name = "click" },
     { name = "pyperclip" },

--- a/uv.lock
+++ b/uv.lock
@@ -529,7 +529,7 @@ requires-dist = [
     { name = "requests", specifier = "==2.32.3" },
     { name = "slack-bolt", specifier = "==1.22.0" },
     { name = "slack-sdk", specifier = "==3.34.0" },
-    { name = "sudden-death", git = "https://github.com/dev-hato/sudden-death?branch=replace_setup_py" },
+    { name = "sudden-death", git = "https://github.com/dev-hato/sudden-death?branch=master" },
     { name = "websockets", specifier = "==14.1" },
 ]
 
@@ -1389,7 +1389,7 @@ wheels = [
 [[package]]
 name = "sudden-death"
 version = "0.0.1"
-source = { git = "https://github.com/dev-hato/sudden-death?branch=replace_setup_py#76e5e2c7935bcc9fe1b59c21a92dbbe2a656af49" }
+source = { git = "https://github.com/dev-hato/sudden-death?branch=master#88ee76a730571c82be27dca439cbb465ef2892e7" }
 dependencies = [
     { name = "click" },
     { name = "pyperclip" },


### PR DESCRIPTION
sudden-deathの対象バージョンをbranchで指定し、それを元にCIでsudden-deathをインストールするようにします。
これにより、sudden-deathのmasterにコミットが積まれたら、ここでPRが立った時にそれが反映されるようになる、はず。

また、sudden-deathが依存していてhato-botは依存していないパッケージ ( `pyperclip`, `click` ) を依存関係から削除します。