### PR TITLE
docker/bake-actionアップデート

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -49,21 +49,21 @@ jobs:
       - run: echo 'TAG_NAME=${{ github.event.release.tag_name }}' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
       - name: Build and push (build)
-        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         env:
           DOCKER_CONTENT_TRUST: 1
         with:
           push: true
           files: build.docker-compose.yml
       - name: Build and push (main)
-        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         env:
           DOCKER_CONTENT_TRUST: 1
         with:
           push: true
           files: docker-compose.yml
       - name: Build and push (dev)
-        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         env:
           DOCKER_CONTENT_TRUST: 1
         with:
@@ -72,7 +72,7 @@ jobs:
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
       - name: Build and push (build) (latest)
-        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         if: ${{ github.event_name == 'release' }}
         env:
           DOCKER_CONTENT_TRUST: 1
@@ -80,7 +80,7 @@ jobs:
           push: true
           files: build.docker-compose.yml
       - name: Build and push (main) (latest)
-        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         if: ${{ github.event_name == 'release' }}
         env:
           DOCKER_CONTENT_TRUST: 1
@@ -88,7 +88,7 @@ jobs:
           push: true
           files: docker-compose.yml
       - name: Build and push (dev) (latest)
-        uses: docker/bake-action@3fc70e1131fee40a422dd8dd0ff22014ae20a1f3 # v5.11.0
+        uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         if: ${{ github.event_name == 'release' }}
         env:
           DOCKER_CONTENT_TRUST: 1

--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -55,6 +55,7 @@ jobs:
         with:
           push: true
           files: build.docker-compose.yml
+          source: .
       - name: Build and push (main)
         uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         env:
@@ -62,6 +63,7 @@ jobs:
         with:
           push: true
           files: docker-compose.yml
+          source: .
       - name: Build and push (dev)
         uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         env:
@@ -69,6 +71,7 @@ jobs:
         with:
           push: true
           files: docker-compose.yml,dev.base.docker-compose.yml
+          source: .
       - run: echo 'TAG_NAME=latest' >> "$GITHUB_ENV"
         if: ${{ github.event_name == 'release' }}
       - name: Build and push (build) (latest)
@@ -79,6 +82,7 @@ jobs:
         with:
           push: true
           files: build.docker-compose.yml
+          source: .
       - name: Build and push (main) (latest)
         uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         if: ${{ github.event_name == 'release' }}
@@ -87,6 +91,7 @@ jobs:
         with:
           push: true
           files: docker-compose.yml
+          source: .
       - name: Build and push (dev) (latest)
         uses: docker/bake-action@5ca506d06f70338a4968df87fd8bfee5cbfb84c7 # v6.0.0
         if: ${{ github.event_name == 'release' }}
@@ -95,6 +100,7 @@ jobs:
         with:
           push: true
           files: docker-compose.yml,dev.base.docker-compose.yml
+          source: .
       - name: Start docker
         env:
           DOCKER_CONTENT_TRUST: 1


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/4640 をベースに `docker/bake-action` をアップデートします。

https://github.com/docker/bake-action/releases/tag/v6.0.0
>This major release uses the [Git context](https://github.com/docker/bake-action?tab=readme-ov-file#git-context) to build from a remote bake definition by default like [docker/build-push-action](https://github.com/docker/build-push-action/?tab=readme-ov-file#git-context) does to be consistent. If you want to keep the old behavior using the [Path context](https://github.com/docker/bake-action?tab=readme-ov-file#path-context), you need to update your workflow and set [source: .](https://github.com/docker/bake-action?tab=readme-ov-file#inputs)

Pathコンテクストで動かさないとビルドが失敗するので、 `source: .` を追加しています。