### PR TITLE
CI pr-format: .env.exampleがある時のみuvのバージョンを更新する

### DIFF
--- a/scripts/pr_format/pr_format/update_uv_version.sh
+++ b/scripts/pr_format/pr_format/update_uv_version.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
+if [ ! -f .env.example ]; then
+  exit 0
+fi
+
 cp .env.example .env
 export TAG_NAME="${HEAD_REF//\//-}"
 docker compose pull


### PR DESCRIPTION
CI `pr-format` において、sudden-deathでuvのバージョンの更新処理が動かないようにします。