### PR TITLE
uvのバージョン修正をCI deploy-hato-botで行う

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -33,10 +33,6 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{steps.generate_token.outputs.token}}
-      - if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        run: bash "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/update_uv_version.sh"
-        env:
-          HEAD_REF: ${{github.head_ref}}
       - name: Set up uv
         uses: astral-sh/setup-uv@4db96194c378173c656ce18a155ffc14a9fc4355 # v5.2.2
         if: github.event_name != 'pull_request' || github.event.action != 'closed'

--- a/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh
+++ b/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh
@@ -7,3 +7,6 @@ DOCKER_CMD="python --version 2>&1 | sed -e 's/^Python //g'"
 python_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
 echo "Python version:" "${python_version}"
 sed -i -e "s/requires-python = \"==.*\"/requires-python = \"==${python_version}\"/g" pyproject.toml
+DOCKER_CMD="uv version | sed -e 's/uv \([0-9.]*\)/\1/g'"
+uv_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
+sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml

--- a/scripts/pr_format/pr_format/update_uv_version.sh
+++ b/scripts/pr_format/pr_format/update_uv_version.sh
@@ -1,8 +1,0 @@
-#!/usr/bin/env bash
-
-cp .env.example .env
-export TAG_NAME="${HEAD_REF//\//-}"
-docker compose pull
-DOCKER_CMD="uv version | sed -e 's/uv \([0-9.]*\)/\1/g'"
-uv_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
-sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml


### PR DESCRIPTION
uvのバージョンはDockerイメージから取得するため、uvのバージョン修正はDockerイメージのビルド後に行う方が都合が良いです。
そのため、この処理をCI `deploy-hato-bot` で行うようにします。