### PR TITLE
uvアップデート

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -15,6 +15,27 @@ on:
       - master
       - develop
 jobs:
+  update-uv-version:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Get uv version
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/update_version_uv_version/get_uv_version.sh"
+        env:
+          HEAD_REF: ${{github.head_ref || github.event.release.tag_name}}
+      - uses: dev-hato/actions-diff-pr-management@cea263ca46759ebc8c812b8595be4df129761037 # v2.1.0
+        with:
+          github-token: ${{secrets.GITHUB_TOKEN}}
+          branch-name-prefix: fix-uv-version
+          pr-title-prefix: uvのバージョンを直してあげたよ！
   deploy_docker_image:
     runs-on: ubuntu-latest
     env:
@@ -25,6 +46,7 @@ jobs:
       contents: read
       packages: write
     if: github.event_name == 'release' || (github.event_name == 'pull_request' && github.event.action != 'closed' && github.repository == github.event.pull_request.head.repo.full_name)
+    needs: update-uv-version
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -28,7 +28,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
       - name: Get uv version
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/update_version_uv_version/get_uv_version.sh"
+        run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh"
         env:
           HEAD_REF: ${{github.head_ref || github.event.release.tag_name}}
       - uses: dev-hato/actions-diff-pr-management@cea263ca46759ebc8c812b8595be4df129761037 # v2.1.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.6.1-python3.13-bookworm-slim@sha256:1658218645a620230c3121cfabb3546adc5085408f6eb152dea615af5dc2710f AS base
+FROM ghcr.io/astral-sh/uv:0.6.2-python3.13-bookworm-slim@sha256:25cfd9fb115d7c3b8a20b9df985a4c082abac1364f84ee94abe451b008e48625 AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [ "python-dotenv==1.0.1", "requests==2.32.3", "Pillow>=7.1.2", "o
 dev = [ "autopep8==2.3.2", "requests-mock==1.12.1", "pylint==3.3.4", "sqlfluff==3.3.1", "mypy==1.15.0", "flake8==7.1.2", "isort==6.0.0", "pre-commit==4.1.0", "importlib-metadata==8.6.1", "toml==0.10.2", "types-toml==0.10.8.20240310", "pyink==24.10.0",]
 
 [tool.uv]
-required-version = "0.6.1"
+required-version = "0.6.2"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple"

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+uv_version=$(grep ghcr.io/astral-sh/uv: Dockerfile | sed -e 's!FROM ghcr.io/astral-sh/uv:\([0-9.]*\)-.*!\1!g')
+sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml

--- a/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh
+++ b/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh
@@ -7,6 +7,3 @@ DOCKER_CMD="python --version 2>&1 | sed -e 's/^Python //g'"
 python_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
 echo "Python version:" "${python_version}"
 sed -i -e "s/requires-python = \"==.*\"/requires-python = \"==${python_version}\"/g" pyproject.toml
-DOCKER_CMD="uv version | sed -e 's/uv \([0-9.]*\)/\1/g'"
-uv_version=$(docker compose run hato-bot sh -c "${DOCKER_CMD}")
-sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/4868 をベースにuvをアップデートします。
Dockerイメージとpyproject.tomlでuvのバージョンが異なるとDockerイメージのビルドがうまくいかないので、pyproject.tomlのuvのバージョンのアップデートをビルド前に行います。