### PR TITLE
super-linterアップデート

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,73 @@
+---
+# https://github.com/super-linter/super-linter/blob/d0b304a6a58b560749c679157953fec8ba7206df/TEMPLATES/.eslintrc.yml
+env:
+  browser: true
+  es6: true
+  jest: true
+  node: true
+extends:
+  - "eslint:recommended"
+ignorePatterns:
+  - "!.*"
+  - "**/node_modules/.*"
+plugins:
+  - n
+  - prettier
+overrides:
+  # JSON files
+  - files:
+      - "*.json"
+    extends:
+      - plugin:jsonc/recommended-with-json
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSON
+  # JSONC files
+  - files:
+      - "*.jsonc"
+    extends:
+      - plugin:jsonc/recommended-with-jsonc
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSONC
+  # JSON5 files
+  - files:
+      - "*.json5"
+    extends:
+      - plugin:jsonc/recommended-with-json5
+    parser: jsonc-eslint-parser
+    parserOptions:
+      jsonSyntax: JSON5
+  # Javascript files
+  - files:
+      - "**/*.js"
+      - "**/*.mjs"
+      - "**/*.cjs"
+      - "**/*.jsx"
+    extends:
+      - "plugin:react/recommended"
+    parserOptions:
+      sourceType: module
+      ecmaVersion: latest
+      ecmaFeatures:
+        jsx: true
+        modules: true
+  # TypeScript files
+  - files:
+      - "**/*.ts"
+      - "**/*.cts"
+      - "**/*.mts"
+      - "**/*.tsx"
+    extends:
+      - "plugin:@typescript-eslint/recommended"
+      - plugin:n/recommended
+      - plugin:react/recommended
+      - prettier
+    rules:
+      n/no-missing-import: off
+    parser: "@typescript-eslint/parser"
+    plugins:
+      - "@typescript-eslint"
+    parserOptions:
+      ecmaVersion: latest
+      sourceType: module

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -44,8 +44,8 @@ overrides:
       - "**/*.mjs"
       - "**/*.cjs"
       - "**/*.jsx"
-    extends:
-      - "plugin:react/recommended"
+    #extends:
+    #  - "plugin:react/recommended"
     parserOptions:
       sourceType: module
       ecmaVersion: latest
@@ -61,7 +61,7 @@ overrides:
     extends:
       - "plugin:@typescript-eslint/recommended"
       - plugin:n/recommended
-      - plugin:react/recommended
+      #- plugin:react/recommended
       - prettier
     rules:
       n/no-missing-import: off

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Install dependencies
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_test/pr_super_lint/npm_ci.sh"
       - name: Lint files
-        uses: super-linter/super-linter/slim@85f7611e0f7b53c8573cca84aa0ed4344f6f6a4d # v7.2.1
+        uses: super-linter/super-linter/slim@4e8a7c2bf106c4c766c816b35ec612638dc9b6b2 # v7.3.0
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_SQLFLUFF: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,6 +38,7 @@ jobs:
           VALIDATE_SQLFLUFF: false
           VALIDATE_CHECKOV: false # TODO: checkovが依存するopenaiのバージョンがアップデートされたら削除
           VALIDATE_JSCPD: false
+          VALIDATE_NATURAL_LANGUAGE: false
           TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_TYPESCRIPT_STANDARD: false
           LINTER_RULES_PATH: .

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,7 +38,6 @@ jobs:
           VALIDATE_SQLFLUFF: false
           VALIDATE_CHECKOV: false # TODO: checkovが依存するopenaiのバージョンがアップデートされたら削除
           VALIDATE_JSCPD: false
-          TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_TYPESCRIPT_STANDARD: false
           LINTER_RULES_PATH: .
           FILTER_REGEX_EXCLUDE: ".*assets/.*.txt"

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -38,7 +38,6 @@ jobs:
           VALIDATE_SQLFLUFF: false
           VALIDATE_CHECKOV: false # TODO: checkovが依存するopenaiのバージョンがアップデートされたら削除
           VALIDATE_JSCPD: false
-          VALIDATE_NATURAL_LANGUAGE: false
           TYPESCRIPT_DEFAULT_STYLE: prettier
           VALIDATE_TYPESCRIPT_STANDARD: false
           LINTER_RULES_PATH: .

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 repos:
   - repo: https://github.com/zricethezav/gitleaks
-    rev: v8.21.2
+    rev: v8.24.0
     hooks:
       - id: gitleaks

--- a/.textlintrc
+++ b/.textlintrc
@@ -24,7 +24,8 @@
             "https://platform.openai.com/api-keys",
             "https://fly.io/dashboard/",
             "https://fly.io/docs/getting-started/launch-demo/#1-install-flyctl",
-            "https://fly.io/docs/getting-started/launch-demo/#2-sign-up-or-sign-in"
+            "https://fly.io/docs/getting-started/launch-demo/#2-sign-up-or-sign-in",
+            "https://ngrok.com/"
         ]
     },
     "no-mixed-zenkaku-and-hankaku-alphabet": true,

--- a/commitlint.config.ts
+++ b/commitlint.config.ts
@@ -1,0 +1,8 @@
+// https://github.com/super-linter/super-linter/blob/5d6e3fcecc2b2906eedc2d15495fd6027bf51a9e/commitlint.config.js
+module.exports = {
+  extends: ["@commitlint/config-conventional"],
+  helpUrl: "https://www.conventionalcommits.org/",
+  // We need this until https://github.com/dependabot/dependabot-core/issues/2445
+  // is resolved.
+  ignores: [(msg: string) => /Signed-off-by: dependabot\[bot]/m.test(msg)],
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,9 +4,11 @@
   "requires": true,
   "packages": {
     "": {
-      "devDependencies": {
+      "dependencies": {
         "@actions/github": "6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "13.3.1",
+        "@octokit/plugin-rest-endpoint-methods": "13.3.1"
+      },
+      "devDependencies": {
         "@proofdict/textlint-rule-proofdict": "3.1.2",
         "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
         "markdownlint-cli": "0.44.0",
@@ -35,7 +37,6 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@actions/github/-/github-6.0.0.tgz",
       "integrity": "sha512-alScpSVnYmjNEXboZjarjukQEzgCRmjMv6Xj47fsdnqGS73bjJNDpiiXmp8jr0UZLdUB6d9jW63IcmddUP+l0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@actions/http-client": "^2.2.0",
@@ -48,7 +49,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
       "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 18"
@@ -58,7 +58,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.0.tgz",
       "integrity": "sha512-1LFfa/qnMQvEOAdzlQymH0ulepxbxnCYAKJZfMci/5XJyIHWgEYnDmgnKakbTh7CH2tFQ5O60oYDvns4i9RAIg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/auth-token": "^4.0.0",
@@ -77,7 +76,6 @@
       "version": "9.0.6",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
       "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
@@ -91,7 +89,6 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
       "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/request": "^8.4.1",
@@ -106,14 +103,12 @@
       "version": "20.0.0",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-20.0.0.tgz",
       "integrity": "sha512-EtqRBEjp1dL/15V7WiX5LJMIxxkdiGJnabzYx5Apx4FkQIFgAfKumXeYAqqJCj1s+BMX4cPFIFC4OLCR6stlnA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@actions/github/node_modules/@octokit/plugin-paginate-rest": {
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-9.2.2.tgz",
       "integrity": "sha512-u3KYkGF7GcZnSD/3UP0S7K5XUFT2FkOQdcfXZGZQPGv3lm4F2Xbf71lvjldr8c1H3nNbF+33cLEkWYbokGWqiQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
@@ -129,7 +124,6 @@
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
@@ -139,7 +133,6 @@
       "version": "10.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-10.4.1.tgz",
       "integrity": "sha512-xV1b+ceKV9KytQe3zCVqjg+8GTGfDYwaT1ATU5isiUyVtlVAO3HNdzpS4sr4GBx4hxQ46s7ITtZrAsxG22+rVg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^12.6.0"
@@ -155,7 +148,6 @@
       "version": "12.6.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-12.6.0.tgz",
       "integrity": "sha512-1rhSOfRa6H9w4YwK0yrf5faDaDTb+yLyBUKOCV4xtCDB5VmIPqd/v9yr9o6SAzOAlRxMiRiCic6JVM1/kunVkw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^20.0.0"
@@ -165,7 +157,6 @@
       "version": "8.4.1",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
       "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/endpoint": "^9.0.6",
@@ -181,7 +172,6 @@
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
       "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.1.0",
@@ -196,21 +186,18 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
-      "dev": true,
       "license": "Apache-2.0"
     },
     "node_modules/@actions/github/node_modules/universal-user-agent": {
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
       "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/@actions/http-client": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/@actions/http-client/-/http-client-2.2.3.tgz",
       "integrity": "sha512-mx8hyJi/hjFvbPokCg4uRd4ZX78t+YyRPtnKWwIl+RzNaVuFpQHfmlGVfsKEJN8LwTCvL+DfVgAM04XaHkm6bA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "tunnel": "^0.0.6",
@@ -713,7 +700,6 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
       "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14"
@@ -894,7 +880,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-5.1.2.tgz",
       "integrity": "sha512-JcQDsBdg49Yky2w2ld20IHAlwr8d/d8N6NiOXbtuoPCqzbsiJgF633mVUw3x4mo0H5ypataQIX7SFu3yy44Mpw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "engines": {
@@ -905,7 +890,6 @@
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/@octokit/core/-/core-6.1.4.tgz",
       "integrity": "sha512-lAS9k7d6I0MPN+gb9bKDt7X8SdxknYqAMh44S5L+lNqIN2NuV8nvv3g8rPp7MuRxcOpxpUIATWprO0C34a8Qmg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -925,7 +909,6 @@
       "version": "10.1.3",
       "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-10.1.3.tgz",
       "integrity": "sha512-nBRBMpKPhQUxCsQQeW+rCJ/OPSMcj3g0nfHn01zGYZXuNDvvXudF/TYY6APj5THlurerpFN4a/dQAIAaM6BYhA==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -940,7 +923,6 @@
       "version": "8.2.1",
       "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-8.2.1.tgz",
       "integrity": "sha512-n57hXtOoHrhwTWdvhVkdJHdhTv0JstjDbDRhJfwIRNfFqmSo1DaK/mD2syoNUoLCyqSjBpGAKOG0BuwF392slw==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -956,14 +938,12 @@
       "version": "23.0.1",
       "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-23.0.1.tgz",
       "integrity": "sha512-izFjMJ1sir0jn0ldEKhZ7xegCTj/ObmEDlEfpFrx4k/JyZSMRHbO3/rBwgE7f3m2DHt+RrNGIVw4wSmwnm3t/g==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
       "version": "13.3.1",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.3.1.tgz",
       "integrity": "sha512-o8uOBdsyR+WR8MK9Cco8dCgvG13H1RlM1nWnK/W7TEACQBFux/vPREgKucxUfuDQ5yi1T3hGf4C5ZmZXAERgwQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/types": "^13.8.0"
@@ -979,7 +959,6 @@
       "version": "9.2.2",
       "resolved": "https://registry.npmjs.org/@octokit/request/-/request-9.2.2.tgz",
       "integrity": "sha512-dZl0ZHx6gOQGcffgm1/Sf6JfEpmh34v3Af2Uci02vzUYz6qEN6zepoRtmybWXIGXFIK8K9ylE3b+duCWqhArtg==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -997,7 +976,6 @@
       "version": "6.1.7",
       "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-6.1.7.tgz",
       "integrity": "sha512-69NIppAwaauwZv6aOzb+VVLwt+0havz9GT5YplkeJv7fG7a40qpLt/yZKyiDxAhgz0EtgNdNcb96Z0u+Zyuy2g==",
-      "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
@@ -1011,7 +989,6 @@
       "version": "13.8.0",
       "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.8.0.tgz",
       "integrity": "sha512-x7DjTIbEpEWXK99DMd01QfWy0hd5h4EN+Q7shkdKds3otGQP+oWE/y0A76i1OvH9fygo4ddvNf7ZvF0t78P98A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@octokit/openapi-types": "^23.0.1"
@@ -1769,7 +1746,6 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-3.0.2.tgz",
       "integrity": "sha512-Nik3Sc0ncrMK4UUdXQmAnRtzmNQTAAXmXIopizwZ1W1t8QmfJj+zL4OA2I7XPTPW5z5TDqv4hRo/JzouDJnX3A==",
-      "dev": true,
       "license": "Apache-2.0",
       "peer": true
     },
@@ -2248,7 +2224,6 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
       "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/dequal": {
@@ -2610,7 +2585,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/fast-content-type-parse/-/fast-content-type-parse-2.0.1.tgz",
       "integrity": "sha512-nGqtvLrj5w0naR6tDPfB4cUmYCqouzyQiz6C5y/LtcDllJdrcc6WaWW6iXyIIOErTa/XRybj28aasdn4LkVk6Q==",
-      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -6522,7 +6496,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
-      "dev": true,
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
@@ -9616,7 +9589,6 @@
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/tunnel/-/tunnel-0.0.6.tgz",
       "integrity": "sha512-1h/Lnq9yajKY2PEbBadPXj3VxsDDu844OnaAo52UVmIzIvwwtBPIuNvkjuzBlTWpfJyUbG3ez0KSBibQkj4ojg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.6.11 <=0.7.0 || >=0.7.3"
@@ -9766,7 +9738,6 @@
       "version": "5.28.5",
       "resolved": "https://registry.npmjs.org/undici/-/undici-5.28.5.tgz",
       "integrity": "sha512-zICwjrDrcrUE0pyyJc1I2QzBkLM8FINsgOrt6WjA+BgajVq9Nxu2PbFFXUrAggLfDXlZGZBVZYw7WNV5KiBiBA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@fastify/busboy": "^2.0.0"
@@ -9899,7 +9870,6 @@
       "version": "7.0.2",
       "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.2.tgz",
       "integrity": "sha512-0JCqzSKnStlRRQfCdowvqy3cy0Dvtlb8xecj/H8JFZuCze4rwjPZQOgvFvn0Ws/usCHQFGpyr+pB9adaGwXn4Q==",
-      "dev": true,
       "license": "ISC",
       "peer": true
     },
@@ -10248,7 +10218,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/write-file-atomic": {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,11 @@
     "lint:dockerfile": "hadolint -c .hadolint.yaml Dockerfile",
     "lint:secret": "docker run --rm --platform=linux/amd64 -v $(pwd):/path -w /path zricethezav/gitleaks protect --verbose --redact"
   },
-  "devDependencies": {
+  "dependencies": {
     "@actions/github": "6.0.0",
-    "@octokit/plugin-rest-endpoint-methods": "13.3.1",
+    "@octokit/plugin-rest-endpoint-methods": "13.3.1"
+  },
+  "devDependencies": {
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
     "markdownlint-cli": "0.44.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ requires-python = "==3.13.2"
 dependencies = [ "python-dotenv==1.0.1", "requests==2.32.3", "Pillow>=7.1.2", "opencv-python==4.11.0.86", "slack-bolt==1.22.0", "slack-sdk==3.34.0", "gitpython==3.1.44", "pandas==2.2.3", "matplotlib==3.10.1", "openai==1.65.4", "discord.py==2.5.2", "misskey.py==4.1.0", "websockets==15.0.1", "flask==3.1.0", "markupsafe==3.0.2", "numpy==2.2.3", "emoji==2.14.1", "puremagic==1.28", "audioop-lts==0.2.1", "psycopg[binary,pool]==3.2.5", "sudden-death==0.0.1",]
 
 [dependency-groups]
-dev = [ "autopep8==2.3.2", "requests-mock==1.12.1", "pylint==3.3.4", "sqlfluff==3.3.1", "mypy==1.15.0", "flake8==7.1.2", "isort==6.0.1", "pre-commit==4.1.0", "importlib-metadata==8.6.1", "toml==0.10.2", "types-toml==0.10.8.20240310", "pyink==24.10.0",]
+dev = [ "autopep8==2.3.2", "requests-mock==1.12.1", "pylint==3.3.4", "sqlfluff==3.3.1", "mypy==1.15.0", "flake8==7.1.2", "isort==6.0.1", "pre-commit==4.1.0", "importlib-metadata==8.6.1", "toml==0.10.2", "types-toml==0.10.8.20240310", "pyink==24.10.1",]
 
 [tool.uv]
 required-version = "0.6.5"

--- a/uv.lock
+++ b/uv.lock
@@ -155,7 +155,7 @@ wheels = [
 
 [[package]]
 name = "black"
-version = "24.8.0"
+version = "24.10.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
@@ -164,9 +164,13 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/04/b0/46fb0d4e00372f4a86a6f8efa3cb193c9f64863615e39010b1477e010578/black-24.8.0.tar.gz", hash = "sha256:2500945420b6784c38b9ee885af039f5e7471ef284ab03fa35ecdde4688cd83f", size = 644810 }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/0d/cc2fb42b8c50d80143221515dd7e4766995bd07c56c9a3ed30baf080b6dc/black-24.10.0.tar.gz", hash = "sha256:846ea64c97afe3bc677b761787993be4991810ecc7a4a937816dd6bddedc4875", size = 645813 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/27/1e/83fa8a787180e1632c3d831f7e58994d7aaf23a0961320d21e84f922f919/black-24.8.0-py3-none-any.whl", hash = "sha256:972085c618ee94f402da1af548a4f218c754ea7e5dc70acb168bfaca4c2542ed", size = 206504 },
+    { url = "https://files.pythonhosted.org/packages/d0/a0/a993f58d4ecfba035e61fca4e9f64a2ecae838fc9f33ab798c62173ed75c/black-24.10.0-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:1cbacacb19e922a1d75ef2b6ccaefcd6e93a2c05ede32f06a21386a04cedb981", size = 1643986 },
+    { url = "https://files.pythonhosted.org/packages/37/d5/602d0ef5dfcace3fb4f79c436762f130abd9ee8d950fa2abdbf8bbc555e0/black-24.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:1f93102e0c5bb3907451063e08b9876dbeac810e7da5a8bfb7aeb5a9ef89066b", size = 1448085 },
+    { url = "https://files.pythonhosted.org/packages/47/6d/a3a239e938960df1a662b93d6230d4f3e9b4a22982d060fc38c42f45a56b/black-24.10.0-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ddacb691cdcdf77b96f549cf9591701d8db36b2f19519373d60d31746068dbf2", size = 1760928 },
+    { url = "https://files.pythonhosted.org/packages/dd/cf/af018e13b0eddfb434df4d9cd1b2b7892bab119f7a20123e93f6910982e8/black-24.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:680359d932801c76d2e9c9068d05c6b107f2584b2a5b88831c83962eb9984c1b", size = 1436875 },
+    { url = "https://files.pythonhosted.org/packages/8d/a7/4b27c50537ebca8bec139b872861f9d2bf501c5ec51fcf897cb924d9e264/black-24.10.0-py3-none-any.whl", hash = "sha256:3bb2b7a1f7b685f85b11fed1ef10f8a9148bceb49853e47a294a3dd963c1dd7d", size = 206898 },
 ]
 
 [[package]]
@@ -542,7 +546,7 @@ dev = [
     { name = "isort", specifier = "==6.0.1" },
     { name = "mypy", specifier = "==1.15.0" },
     { name = "pre-commit", specifier = "==4.1.0" },
-    { name = "pyink", specifier = "==24.10.0" },
+    { name = "pyink", specifier = "==24.10.1" },
     { name = "pylint", specifier = "==3.3.4" },
     { name = "requests-mock", specifier = "==1.12.1" },
     { name = "sqlfluff", specifier = "==3.3.1" },
@@ -1184,7 +1188,7 @@ wheels = [
 
 [[package]]
 name = "pyink"
-version = "24.10.0"
+version = "24.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "black" },
@@ -1194,9 +1198,9 @@ dependencies = [
     { name = "pathspec" },
     { name = "platformdirs" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/57/2e/5876fbad09a89b1f3ef999c53fa46f76d97b96ae5a4d3ce9e1419bf81b47/pyink-24.10.0.tar.gz", hash = "sha256:3217023e5875c269c2cfd5b22bcec973b7ceb3592b87b45b3373f29e95647c54", size = 266231 }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/a1/e5e28626fca4266a94c2e1c9264fbf915b9e83e94f52e965190e48fd0cbf/pyink-24.10.1.tar.gz", hash = "sha256:5ec4339aa4953f796e88d90bcac3e3472161e4c36dbde203d80f5f76721ac718", size = 267230 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/93/72/37d76e26bc9cc5ffb90cd2c29adcf0476922e8d89da6061682298e231a3b/pyink-24.10.0-py3-none-any.whl", hash = "sha256:98d5250e77a44e906d8fcbf10582ca12f2404a0d38dfe99320bf81ca08c418b9", size = 136396 },
+    { url = "https://files.pythonhosted.org/packages/1f/12/2f271b3601ae25731879f160d6b3941d80eb6b4f3e24be90289e33fb1dc4/pyink-24.10.1-py3-none-any.whl", hash = "sha256:6349bf6ab75e2ea39a5f0bc3dee7ede7f4af8529291472638026de5fd4af80d2", size = 137118 },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/4901 をベースにsuper-linterをアップデートします。
以下も行っています。
* `n/no-unpublished-import` に引っかからないよう、スクリプト内でimportしているパッケージを `dependencies` に移動
* `n/no-missing-import` については解決が難しそうなので一旦無効化
* textlint-rule-no-dead-linkによる https://ngrok.com/ のチェックを行うとsuper-linterの実行が終わらなくなるのでチェック対象から除外
* 以下のWarning修正
   https://github.com/dev-hato/hato-bot/actions/runs/13733580708/job/38414470358#step:9:157

   ```
     2025-03-08 03:31:48 [WARN]   Git commit message validation with commitlint is enabled, but no commitlint configuration file is available. Disabling commitlint. To suppress this message, either disable Git commit validation by setting VALIDATE_GIT_COMMITLINT to false in your Super-linter configuration, or provide a commitlint configuration file.
     2025-03-08 03:31:48 [WARN]   TYPESCRIPT_DEFAULT_STYLE environment variable is set, it's deprecated, and super-linter will ignore it. Remove it from your configuration. This warning may turn in a fatal error in the future. For more information, see the upgrade guide: https://github.com/super-linter/super-linter/blob/main/docs/upgrade-guide.md
   ```
   
   https://github.com/dev-hato/hato-bot/actions/runs/13733580708/job/38414470358#step:9:598
   
   ```
     Warning: React version not specified in eslint-plugin-react settings. See https://github.com/jsx-eslint/eslint-plugin-react#configuration .
   ```