### PR TITLE
renovate: slack関連のパッケージをまとめる

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "ignoreDeps": ["pyink"],
   "packageRules": [
     {
+      "groupName": "slack",
+      "matchPackageNames": ["slack-bolt", "slack-sdk"]
+    },
+    {
       "matchPackageNames": ["postgres"],
       "matchUpdateTypes": ["major"],
       "enabled": false


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/5012 と https://github.com/dev-hato/hato-bot/pull/5013 は依存関係の都合上、 https://github.com/dev-hato/hato-bot/pull/5013 -> https://github.com/dev-hato/hato-bot/pull/5012 の順にアップデートする必要がありました。
このような場合に依存関係を気にしなくて良いよう、 `slack-bolt` と `slack-sdk` のアップデートPRを一つにまとめます．