### PR TITLE
renovate: uvアップデートを最優先にする

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,10 @@
   "ignoreDeps": ["pyink"],
   "packageRules": [
     {
+      "matchPackageNames": ["ghcr.io/astral-sh/uv"],
+      "prPriority": 10
+    },
+    {
       "groupName": "slack",
       "matchPackageNames": ["slack-bolt", "slack-sdk"]
     },


### PR DESCRIPTION
uvのバージョンがrenovateの求めるものより古く、renovateがうまく動かないことがあるので、 `ghcr.io/astral-sh/uv` のアップデートPRを最優先で出すようにします。