### PR TITLE
actions/checkoutにpersist-credentials: falseをセットする

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -26,6 +26,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Get uv version
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh"
@@ -51,6 +52,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set .env
         run: cp .env.example .env
       - name: Login to GitHub Container Registry
@@ -144,6 +146,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Get Python version
         id: get_python_version
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -168,6 +171,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
@@ -196,6 +200,7 @@ jobs:
           # submodule: 'recursive'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
@@ -218,6 +223,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: dev-hato/actions-update-dockle@f95d8f643c638d132b0d1daf3e3c8910a12863df # v0.0.110
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
@@ -231,6 +237,8 @@ jobs:
       REPOSITORY: ${{github.repository}}
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/dockle/run_dockle.sh"
         env:
           HEAD_REF: ${{github.head_ref || github.event.release.tag_name}}

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -30,6 +30,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{steps.generate_token.outputs.token}}
+          persist-credentials: false
       - uses: dev-hato/actions-format-json-yml@78a2502c69645dbbd3a56168ddc69065e7ee538c # v0.0.81
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/format-json-yml.yml
+++ b/.github/workflows/format-json-yml.yml
@@ -18,19 +18,18 @@ jobs:
   format-json-yml:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - name: Generate a token
         id: generate_token
         uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
           private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
-        if: github.event_name != 'pull_request' || github.event.action != 'closed'
-        with:
-          fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{steps.generate_token.outputs.token}}
-          persist-credentials: false
       - uses: dev-hato/actions-format-json-yml@78a2502c69645dbbd3a56168ddc69065e7ee538c # v0.0.81
         with:
           github-token: ${{steps.generate_token.outputs.token}}

--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -13,6 +13,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - uses: dev-hato/github-actions-cache-cleaner@7951d10ece225d39f225997fbff2d14f6c44bfa1 # v0.0.63
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -10,6 +10,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -20,12 +20,6 @@ jobs:
   pr-format:
     runs-on: ubuntu-latest
     steps:
-      - name: Generate a token
-        id: generate_token
-        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
-        with:
-          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
-          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:
@@ -33,7 +27,6 @@ jobs:
           # submodule: 'recursive'
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
-          token: ${{steps.generate_token.outputs.token}}
           persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
@@ -43,6 +36,12 @@ jobs:
       - name: Install dependencies
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/uv_install.sh"
+      - name: Generate a token
+        id: generate_token
+        uses: actions/create-github-app-token@3ff1caaa28b64c9cc276ce0a02e2ff584f3900c5 # v2.0.2
+        with:
+          app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}
+          private-key: ${{ secrets.PROJECT_AUTOMATION_PRIVATE_KEY }}
       # formatする
       # --exit-codeをつけることで、autopep8内でエラーが起きれば1、差分があれば2のエラーステータスコードが返ってくる。正常時は0が返る
       - name: Format files

--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -34,6 +34,7 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
           token: ${{steps.generate_token.outputs.token}}
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
         if: github.event_name != 'pull_request' || github.event.action != 'closed'

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -13,6 +13,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -12,6 +12,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up Node.js
         uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         with:

--- a/.github/workflows/pr-test-hato-bot.yml
+++ b/.github/workflows/pr-test-hato-bot.yml
@@ -16,6 +16,7 @@ jobs:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           submodules: "recursive"
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
         with:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -14,6 +14,7 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 0
+          persist-credentials: false
       - name: Set up uv
         uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182 # v5.4.1
         with:
@@ -53,6 +54,7 @@ jobs:
         with:
           submodules: "recursive"
           fetch-depth: 0
+          persist-credentials: false
       - name: Lint dotenv
         uses: dotenv-linter/action-dotenv-linter@382525b7d91e7b71b52e064b8f1fa5908c4650d2 # v2.24.0
 concurrency:

--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -22,6 +22,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - uses: actions/setup-node@cdca7365b2dadb8aad0a33bc7601856ffabcc48e # v4.3.0
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         with:

--- a/.github/workflows/update-readme-hato-bot.yml
+++ b/.github/workflows/update-readme-hato-bot.yml
@@ -19,6 +19,7 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha }}
+          persist-credentials: false
       - run: perl -pe "s/{commands}/$(sed -e '2,$s/^/    /' commands.txt)/g" < README.template.md > README.md
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
       - uses: dev-hato/actions-diff-pr-management@cea263ca46759ebc8c812b8595be4df129761037 # v2.1.0


### PR DESCRIPTION
https://zenn.dev/shunsuke_suzuki/articles/github-action-checkout-persist-credentials

`actions/checkout` で使ったtokenが後続のstepで使われないよう、 `persist-credentials: false` をセットします。

また、GitHub Appでのtoken生成処理に関して以下を行います。
* checkout時のtokenをデフォルトのものにする
* GitHub Appでtokenを生成するタイミングをtokenを使用する直前にする