### PR TITLE
node-fetchダウングレード

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -35,4 +35,6 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    ignore:
+      - dependency-name: "node-fetch"
     open-pull-requests-limit: 1

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@proofdict/textlint-rule-proofdict": "3.1.2",
         "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
         "markdownlint-cli": "0.45.0",
+        "node-fetch": "2.6.12",
         "textlint": "14.7.2",
         "textlint-filter-rule-comments": "1.2.2",
         "textlint-rule-abbr-within-parentheses": "1.0.2",
@@ -6486,9 +6487,9 @@
       }
     },
     "node_modules/node-fetch": {
-      "version": "2.6.13",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.13.tgz",
-      "integrity": "sha512-StxNAxh15zr77QvvkmveSQ8uCQ4+v5FkvNTj0OESmiHu+VRi/gXArXtkWMElOsOUNLtUEvI4yS+rdtOHZTwlQA==",
+      "version": "2.6.12",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.12.tgz",
+      "integrity": "sha512-C/fGU2E8ToujUivIO0H+tpQ6HWo4eEmchoPIoXtxCrVghxdKq+QOHqEZW7tuP3KlV3bC8FRMO5nMCC7Zm1VP6g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@proofdict/textlint-rule-proofdict": "3.1.2",
     "@textlint-ja/textlint-rule-no-insert-dropping-sa": "2.0.1",
     "markdownlint-cli": "0.45.0",
+    "node-fetch": "2.6.12",
     "textlint": "14.7.2",
     "textlint-filter-rule-comments": "1.2.2",
     "textlint-rule-abbr-within-parentheses": "1.0.2",

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": ["pyink"],
+  "ignoreDeps": ["pyink", "node-fetch"],
   "packageRules": [
     {
       "matchPackageNames": ["ghcr.io/astral-sh/uv"],


### PR DESCRIPTION
https://github.com/dev-hato/sudden-death/pull/2884, https://github.com/dev-hato/sudden-death/pull/2886, https://github.com/dev-hato/sudden-death/pull/2890, https://github.com/dev-hato/sudden-death/pull/2889 でsuper-linterの実行が終わらなくなっているので、 https://github.com/dev-hato/hato-atama/pull/3551 と同様に `node-fetch` を2.6.12で固定します。