### PR TITLE
pyproject.toml: dependenciesを改行する

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,10 +3,46 @@ name = "hato-bot"
 version = "3.0.5"
 description = "愛嬌のあるBot"
 requires-python = "==3.13.5"
-dependencies = [ "python-dotenv==1.1.1", "requests==2.32.4", "Pillow>=7.1.2", "opencv-python==4.12.0.88", "slack-bolt==1.23.0", "slack-sdk==3.36.0", "gitpython==3.1.44", "pandas==2.3.1", "matplotlib==3.10.3", "openai==1.93.3", "discord.py==2.5.2", "misskey.py==4.1.0", "websockets==15.0.1", "flask==3.1.1", "markupsafe==3.0.2", "numpy==2.2.6", "emoji==2.14.1", "puremagic==1.30", "audioop-lts==0.2.1", "psycopg[binary,pool]==3.2.9", "sudden-death==0.0.1",]
+dependencies = [
+    "python-dotenv==1.1.1",
+    "requests==2.32.4",
+    "Pillow>=7.1.2",
+    "opencv-python==4.12.0.88",
+    "slack-bolt==1.23.0",
+    "slack-sdk==3.36.0",
+    "gitpython==3.1.44",
+    "pandas==2.3.1",
+    "matplotlib==3.10.3",
+    "openai==1.93.3",
+    "discord.py==2.5.2",
+    "misskey.py==4.1.0",
+    "websockets==15.0.1",
+    "flask==3.1.1",
+    "markupsafe==3.0.2",
+    "numpy==2.2.6",
+    "emoji==2.14.1",
+    "puremagic==1.30",
+    "audioop-lts==0.2.1",
+    "psycopg[binary,pool]==3.2.9",
+    "sudden-death==0.0.1",
+    "tomlkit==0.13.3",
+]
 
 [dependency-groups]
-dev = [ "autopep8==2.3.2", "requests-mock==1.12.1", "pylint==3.3.7", "sqlfluff==3.4.1", "mypy==1.16.1", "flake8==7.3.0", "isort==6.0.1", "pre-commit==4.2.0", "importlib-metadata==8.7.0", "toml==0.10.2", "types-toml==0.10.8.20240310", "pyink==24.10.1",]
+dev = [
+  "autopep8==2.3.2",
+  "requests-mock==1.12.1",
+  "pylint==3.3.7",
+  "sqlfluff==3.4.1",
+  "mypy==1.16.1",
+  "flake8==7.3.0",
+  "isort==6.0.1",
+  "pre-commit==4.2.0",
+  "importlib-metadata==8.7.0",
+  "toml==0.10.2",
+  "types-toml==0.10.8.20240310",
+  "pyink==24.10.1",
+]
 
 [tool.uv]
 required-version = "0.7.20"

--- a/scripts/pr_format/pr_format/fix_pyproject.py
+++ b/scripts/pr_format/pr_format/fix_pyproject.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from typing import NoReturn, TypeGuard
 
 import importlib_metadata
-import toml
+import tomlkit
 
 # pyproject.tomlのproject.dependenciesやdependency-groups.devのデータ型
 PyProjectDependencies = list[str]
@@ -232,7 +232,8 @@ def main():
     if not pyproject_path.exists():
         raise FileNotFoundError("pyproject.toml not found.")
 
-    pyproject = toml.load(pyproject_path)
+    with open(pyproject_path) as f:
+        pyproject = tomlkit.load(f)
 
     if not is_pyproject_dependencies(pyproject["project"]["dependencies"]):
         raise TypeError(
@@ -260,7 +261,7 @@ def main():
     )
 
     with open(pyproject_path, "w") as f:
-        toml.dump(pyproject, f)
+        tomlkit.dump(pyproject, f)
 
 
 if __name__ == "__main__":

--- a/uv.lock
+++ b/uv.lock
@@ -515,6 +515,7 @@ dependencies = [
     { name = "slack-bolt" },
     { name = "slack-sdk" },
     { name = "sudden-death" },
+    { name = "tomlkit" },
     { name = "websockets" },
 ]
 
@@ -556,6 +557,7 @@ requires-dist = [
     { name = "slack-bolt", specifier = "==1.23.0" },
     { name = "slack-sdk", specifier = "==3.36.0" },
     { name = "sudden-death", git = "https://github.com/dev-hato/sudden-death?branch=master" },
+    { name = "tomlkit", specifier = "==0.13.3" },
     { name = "websockets", specifier = "==15.0.1" },
 ]
 


### PR DESCRIPTION
`pyproject.toml` の `dependencies` を見やすいように改行します。
また、その状態を維持できるよう、 `scripts/pr_format/pr_format/fix_pyproject.py` でのTOMLの `pyproject.toml` の読み書きに使うパッケージを `tomlkit` に変更します。