### PR TITLE
textlint-rule-terminologyアップデート

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@
 
 ### Changed
 
-- slack sdkを置き換えました。(#2668, #2697)
+- Slack sdkを置き換えました。(#2668, #2697)
 
 ### Fixed
 
@@ -145,13 +145,13 @@
 
 ### Fixed
 
-- docker compose時の `TAG_NAME` を指定する際のコマンドを修正しました。(#802)
+- Docker compose時の `TAG_NAME` を指定する際のコマンドを修正しました。(#802)
 
 ## v2.2.1 - 2022-02-11
 
 ### Fixed
 
-- docker compose時に `TAG_NAME` を指定する記述を追加しました。(#788)
+- Docker compose時に `TAG_NAME` を指定する記述を追加しました。(#788)
 
 ## v2.2.0 - 2022-02-10
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@
 
    MODEに `misskey` を指定すると、自分のいるサーバーからのメンションに限って反応するMisskeyのBotとして動作します。
 
-6. docker composeで鳩botとPostgreSQLを起動します。
+6. Docker composeで鳩botとPostgreSQLを起動します。
 
    ```sh
    export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")
@@ -108,7 +108,7 @@
    docker compose -f docker-compose.yml -f dev.base.docker-compose.yml -f dev.docker-compose.yml watch
    ```
 
-7. コードの変更はdocker composeの再起動で適用できます。
+7. コードの変更はDocker composeの再起動で適用できます。
 
    ```sh
    export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")

--- a/README.template.md
+++ b/README.template.md
@@ -93,7 +93,7 @@
 
    MODEに `misskey` を指定すると、自分のいるサーバーからのメンションに限って反応するMisskeyのBotとして動作します。
 
-6. docker composeで鳩botとPostgreSQLを起動します。
+6. Docker composeで鳩botとPostgreSQLを起動します。
 
    ```sh
    export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")
@@ -108,7 +108,7 @@
    docker compose -f docker-compose.yml -f dev.base.docker-compose.yml -f dev.docker-compose.yml watch
    ```
 
-7. コードの変更はdocker composeの再起動で適用できます。
+7. コードの変更はDocker composeの再起動で適用できます。
 
    ```sh
    export TAG_NAME=$(git symbolic-ref --short HEAD | sed -e "s:/:-:g")

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "textlint-rule-prefer-tari-tari": "1.0.3",
         "textlint-rule-preset-ja-spacing": "2.4.3",
         "textlint-rule-preset-ja-technical-writing": "12.0.2",
-        "textlint-rule-terminology": "5.2.13",
+        "textlint-rule-terminology": "5.2.14",
         "tsx": "4.20.3"
       },
       "engines": {
@@ -9841,9 +9841,9 @@
       }
     },
     "node_modules/textlint-rule-terminology": {
-      "version": "5.2.13",
-      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.2.13.tgz",
-      "integrity": "sha512-NHCjVue34iP8P+zko39hut0iJ/sc8QfsSSqSOvWHuRZWIt6jUoQrpkfGdRNTkzN++l2uv9qBIhtRPkYv25LY8w==",
+      "version": "5.2.14",
+      "resolved": "https://registry.npmjs.org/textlint-rule-terminology/-/textlint-rule-terminology-5.2.14.tgz",
+      "integrity": "sha512-OYvLq+K+HpQqxWhV9MXb/jnND8oWxUbZK+OmrqO8auO2TWMky22ZlR8qoAmlzYbRMR1S3LJyifFlThZoXbD1uA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "textlint-rule-prefer-tari-tari": "1.0.3",
     "textlint-rule-preset-ja-spacing": "2.4.3",
     "textlint-rule-preset-ja-technical-writing": "12.0.2",
-    "textlint-rule-terminology": "5.2.13",
+    "textlint-rule-terminology": "5.2.14",
     "tsx": "4.20.3"
   },
   "engines": {


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/5472 をベースに `textlint-rule-terminology` をアップデートします。