### PR TITLE
dependabot: 3日以上経ったnpmパッケージのみをアップデート対象にする

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -36,3 +36,5 @@ updates:
     ignore:
       - dependency-name: "node-fetch"
     open-pull-requests-limit: 1
+    cooldown:
+      default-days: 3


### PR DESCRIPTION
https://tech.dentsusoken.com/entry/dependabot_cooldown

https://github.com/dev-hato/renovate-config/pull/1808 と同様の設定をdependabotに対して行います。