### PR TITLE
scriptの宣言方法修正

### DIFF
--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -31,7 +31,7 @@ jobs:
           github-token: ${{steps.generate_token.outputs.token}}
           script: |
             const {tsImport} = require('tsx/esm/api')
-            const {script} = await tsImport(
+            const {default: {script}} = await tsImport(
               './scripts/pr_copy_ci_hato_bot/pr_copy_ci/dispatch_event.ts',
               process.env.GITHUB_WORKSPACE + '/'
             )

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -30,7 +30,7 @@ jobs:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
             const {tsImport} = require('tsx/esm/api')
-            const {script} = await tsImport(
+            const {default: {script}} = await tsImport(
               './scripts/get_pull_requests_hato_bot.ts',
               process.env.GITHUB_WORKSPACE + '/'
             )


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/17598742432/job/49996557858

```
TypeError: script is not a function
    at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:36187:16), <anonymous>:8:7)
    at async main (/home/runner/work/_actions/actions/github-script/ed597411d8f924073f98dfc5c65a23a2325f34cd/dist/index.js:36285:20)
Error: Unhandled error: TypeError: script is not a function
```

https://github.com/dev-hato/hato-bot/pull/5742 により、CIが失敗するようになっているので、 `script` の宣言方法を修正します。