### PR TITLE
super-linterアップデート

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Install dependencies
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_test/pr_super_lint/npm_ci.sh"
       - name: Lint files
-        uses: super-linter/super-linter/slim@ffde3b2b33b745cb612d787f669ef9442b1339a6 # v8.1.0
+        uses: super-linter/super-linter/slim@7bba2eeb89d01dc9bfd93c497477a57e72c83240 # v8.2.0
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_SQLFLUFF: false

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -54,6 +54,7 @@ jobs:
           VALIDATE_TRIVY: false
           VALIDATE_BIOME_FORMAT: false
           VALIDATE_BIOME_LINT: false
+          VALIDATE_PYTHON_RUFF: false
   pr-dotenv-linter:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -52,6 +52,8 @@ jobs:
           VALIDATE_GIT_COMMITLINT: false
           VALIDATE_GITHUB_ACTIONS_ZIZMOR: false
           VALIDATE_TRIVY: false
+          VALIDATE_BIOME_FORMAT: false
+          VALIDATE_BIOME_LINT: false
   pr-dotenv-linter:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/5853 をベースにsuper-linterをアップデートします。
`.venv` 以下も見てしまうので、 `BIOME_FORMAT` と `BIOME_LINT` を無効化します。

https://github.com/dev-hato/hato-bot/actions/runs/18238797856/job/51937508583#step:9:192

```
  2025-10-04 03:14:07 [WARN]   Black and Ruff are both enabled, and might conflict with each other. To avoid potential conflicts, keep only one of the two enabled, and disable the other.
```