### PR TITLE
CI pr-format: 成功/失敗に関わらずtokenを発行する

### DIFF
--- a/.github/workflows/pr-format.yml
+++ b/.github/workflows/pr-format.yml
@@ -41,6 +41,7 @@ jobs:
         run: bash "${GITHUB_WORKSPACE}/scripts/uv_install.sh"
       - name: Generate a token
         id: generate_token
+        if: success() || failure()
         uses: actions/create-github-app-token@67018539274d69449ef7c02e8e71183d1719ab42 # v2.1.4
         with:
           app-id: ${{ secrets.PROJECT_AUTOMATION_APP_ID }}


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/18541643613/job/52850339301

```
Error: Unhandled error: Error: Input required and not supplied: github-token
```

CIの失敗時にもtokenを発行するようにしないと、 `dev-hato/actions-diff-pr-management` にてエラーになってしまうため、成功/失敗に関わらずtokenを発行するようにします。