### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -9,6 +9,10 @@ on:
       - opened
 jobs:
   add-to-task-list:
+    permissions:
+      issues: write
+      pull-requests: write
+      contents: read
     runs-on: ubuntu-latest
     if: github.event_name == 'issues' || github.repository == github.event.pull_request.head.repo.full_name
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/dev-hato/hato-bot/security/code-scanning/6](https://github.com/dev-hato/hato-bot/security/code-scanning/6)

To fix this issue, you need to add a `permissions` block to the workflow, ideally at the job level (under `add-to-task-list`) to restrict the permissions to only those needed for the actions. Since the workflow interacts with issues and possibly project items, but not necessarily source code (contents), the minimal permissions necessary are likely: `issues: write`, `pull-requests: write`, and possibly `contents: read` (for basic access, but not write). This block should be inserted immediately before `runs-on: ubuntu-latest` in the job definition. No external libraries are needed for this kind of configuration change; it's a YAML file edit only.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
