### PR TITLE
permissionsを空にする

### DIFF
--- a/.github/workflows/add-to-task-list.yml
+++ b/.github/workflows/add-to-task-list.yml
@@ -7,6 +7,7 @@ on:
   issues:
     types:
       - opened
+permissions: {}
 jobs:
   add-to-task-list:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -17,6 +17,7 @@ on:
     branches:
       - master
       - develop
+permissions: {}
 jobs:
   update-uv-version:
     runs-on: ubuntu-latest

--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     - cron: "0 21 * * *" # 06:00 JST
   workflow_dispatch:
+permissions: {}
 jobs:
   github-actions-cache-cleaner:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-copy-ci-hato-bot.yml
+++ b/.github/workflows/pr-copy-ci-hato-bot.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - develop
   workflow_dispatch:
+permissions: {}
 jobs:
   pr-copy-ci:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-merge-develop-hato-bot.yml
+++ b/.github/workflows/pr-merge-develop-hato-bot.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+permissions: {}
 jobs:
   # masterにコミットがpushされたら、それをdevelopに反映するPRを作成するjob
   # masterとdevelopの間でコミットログに差異が出ないようにする

--- a/.github/workflows/pr-release-hato-bot.yml
+++ b/.github/workflows/pr-release-hato-bot.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - develop
+permissions: {}
 jobs:
   # リリース用のPRを作成するjob
   pr-release:

--- a/.github/workflows/pr-test-hato-bot.yml
+++ b/.github/workflows/pr-test-hato-bot.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+permissions: {}
 jobs:
   # unittestを行う
   # testが落ちたらチェックが落ちる

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -9,6 +9,7 @@ on:
     branches:
       - master
       - develop
+permissions: {}
 jobs:
   pr-super-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/update-readme-hato-bot.yml
+++ b/.github/workflows/update-readme-hato-bot.yml
@@ -13,6 +13,7 @@ on:
   push:
     branches:
       - master
+permissions: {}
 jobs:
   update-readme:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Code scanning alertsでpermissionsが設定されていない旨を指摘されているので設定します。
一旦空で設定します。