### PR TITLE
renovate・dependabot: numpyやclickをアップデート対象から外す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ updates:
       interval: "daily"
     ignore:
       - dependency-name: mypy
+      - dependency-name: numpy
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,7 @@ updates:
     ignore:
       - dependency-name: mypy
       - dependency-name: numpy
+      - dependency-name: click
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": ["node-fetch", "sudden-death", "mypy"],
+  "ignoreDeps": ["node-fetch", "sudden-death", "mypy", "numpy"],
   "packageRules": [
     {
       "matchPackageNames": ["ghcr.io/astral-sh/uv"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": ["node-fetch", "sudden-death", "mypy", "numpy"],
+  "ignoreDeps": ["node-fetch", "sudden-death", "mypy", "numpy", "click"],
   "packageRules": [
     {
       "matchPackageNames": ["ghcr.io/astral-sh/uv"],


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/19800692683/job/56727536505

`opencv-python` は `numpy` に依存していますが、 `numpy` をアップデートすると依存関係が壊れるようです。

https://github.com/dev-hato/sudden-death/actions/runs/19752821489/job/56598794284

同様に `sqlfluff` は `click` に依存していますが、 `click` をアップデートすると依存関係が壊れるようです。

うまく動かないアップデートPRがずっといてもよくないので、一旦 `numpy` や `click` をrenovateやdependabotによるアップデート対象から外します。