### PR TITLE
シェルスクリプトの実行に失敗したらCIも失敗するようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,7 +54,8 @@ RUN if [ "${ENV}" = 'dev' ]; then \
       uv sync --frozen --dev; \
     else \
       uv sync --frozen; \
-    fi
+    fi && \
+    rm -rf ~/.cache
 
 USER root
 

--- a/scripts/deploy_hato_bot/dockle/run_dockle.sh
+++ b/scripts/deploy_hato_bot/dockle/run_dockle.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 cp .env.example .env
 export TAG_NAME="${HEAD_REF//\//-}"

--- a/scripts/deploy_hato_bot/dockle/run_dockle.sh
+++ b/scripts/deploy_hato_bot/dockle/run_dockle.sh
@@ -15,7 +15,7 @@ for image_name in $(docker compose images | awk 'OFS=":" {print $2,$3}' | tail -
 	if [[ "${image_name}" =~ "postgres" ]]; then
 		cmd+="-ak key "
 	elif [[ "${image_name}" =~ "hato-bot" ]]; then
-		cmd+="-i CIS-DI-0006 "
+		cmd+="-i CIS-DI-0006 -af settings.py "
 	fi
 
 	cmd+="${image_name}"

--- a/scripts/deploy_hato_bot/npm_install.sh
+++ b/scripts/deploy_hato_bot/npm_install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 bash "${GITHUB_WORKSPACE}/scripts/install_npm.sh"
 npm install

--- a/scripts/deploy_hato_bot/pr_update_version/get_npm_version.sh
+++ b/scripts/deploy_hato_bot/pr_update_version/get_npm_version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 DOCKER_CMD="npm --version"
 DEPENDABOT_NPM_VERSION="10.9.3"

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 uv_version=$(grep ghcr.io/astral-sh/uv: Dockerfile | sed -e 's!FROM ghcr.io/astral-sh/uv:\([0-9.]*\)-.*!\1!g')
 sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml

--- a/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh
+++ b/scripts/deploy_hato_bot/update_version_python_version/get_python_version.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 cp .env.example .env
 export TAG_NAME="${HEAD_REF//\//-}"

--- a/scripts/install_npm.sh
+++ b/scripts/install_npm.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 npm_version=$(jq -r '.engines.npm | ltrimstr("^")' package.json)
 npm install --location=global "npm@${npm_version}"

--- a/scripts/npm_ci.sh
+++ b/scripts/npm_ci.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 bash "${GITHUB_WORKSPACE}/scripts/install_npm.sh"
 npm ci

--- a/scripts/pr_format/pr_format/format.sh
+++ b/scripts/pr_format/pr_format/format.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 uv run "${GITHUB_WORKSPACE}/scripts/pr_format/pr_format/fix_pyproject.py"
 action="$(yq '.jobs.pr-super-lint.steps[-1].uses | line_comment' .github/workflows/pr-test.yml)"

--- a/scripts/pr_release_hato_bot/pr_release/get_diff.sh
+++ b/scripts/pr_release_hato_bot/pr_release/get_diff.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 result=$(git diff origin/develop origin/master)
 echo "${result}"

--- a/scripts/pr_test/pr_super_lint/npm_ci.sh
+++ b/scripts/pr_test/pr_super_lint/npm_ci.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 bash "${GITHUB_WORKSPACE}/scripts/npm_ci.sh"
 echo "PYTHONPATH=/github/workspace/:/github/workflow/.venv/lib/python$(uv run "${GITHUB_WORKSPACE}/scripts/pr_test/pr_super_lint/get_python_version.py")/site-packages" >>"${GITHUB_ENV}"

--- a/scripts/pr_test/pr_super_lint/set_venv_path.sh
+++ b/scripts/pr_test/pr_super_lint/set_venv_path.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 # 環境ファイルを使ってenvにsetしている
 # 参考URL: https://bit.ly/2KJhjqk

--- a/scripts/pr_test_hato_bot/pr_test/test.sh
+++ b/scripts/pr_test_hato_bot/pr_test/test.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 cp .env.example .env
 uv run python -m unittest

--- a/scripts/uv_install.sh
+++ b/scripts/uv_install.sh
@@ -1,4 +1,5 @@
 #!/usr/bin/env bash
+set -e
 
 uv --version
 uv python install


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/19873112801/job/56954930692#step:3:657

```
> dockle --exit-code 1 -i CIS-DI-0006 ghcr.io/dev-hato/hato-bot/hato-bot:develop
FATAL	- CIS-DI-0010: Do not store credential in environment variables/files
	* Suspicious filename found : usr/src/app/.venv/lib/python3.14/site-packages/dill/settings.py (You can suppress it with "-af settings.py")
	* Suspicious filename found : home/nonroot/.cache/uv/archive-v0/XvuT6UafbUweEQWVjMegB/dill/settings.py (You can suppress it with "-af settings.py")
	* Suspicious filename found : home/nonroot/.cache/uv/archive-v0/qE32YRUKel6FQaLMuHwdB/isort/settings.py (You can suppress it with "-af settings.py")
	* Suspicious filename found : usr/src/app/.venv/lib/python3.14/site-packages/isort/settings.py (You can suppress it with "-af settings.py")
INFO	- DKL-LI-0003: Only put necessary files
	* Suspicious directory : home/nonroot/.cache/uv/git-v0/db/25bdb562c51c7c44/.git 
	* Suspicious directory : home/nonroot/.cache/uv/git-v0/checkouts/25bdb562c51c7c44/09e7c52/.git 
```

CI `dockle` で指摘事項が出ているにも関わらず、CIが失敗していませんでした。
そのため、CIのシェルスクリプトに `set -e` を入れてシェルスクリプト内のコマンド実行に失敗したらCIの実行も失敗するようにします。
また、指摘事項に合わせて修正しています。