### PR TITLE
CI github-actions-cache-cleaner: permissions修正

### DIFF
--- a/.github/workflows/github-actions-cache-cleaner.yml
+++ b/.github/workflows/github-actions-cache-cleaner.yml
@@ -8,7 +8,8 @@ on:
   schedule:
     - cron: "0 21 * * *" # 06:00 JST
   workflow_dispatch:
-permissions: {}
+permissions:
+  actions: write
 jobs:
   github-actions-cache-cleaner:
     runs-on: ubuntu-latest


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/20101625828/job/57673830387#step:3:50

```
'x-accepted-github-permissions': 'actions=write',
```

CI `github-actions-cache-cleaner` がエラーになっているのでpermissionsを修正します。