### PR TITLE
CI pr-super-lint: permissions修正

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -13,6 +13,8 @@ permissions: {}
 jobs:
   pr-super-lint:
     runs-on: ubuntu-latest
+    permissions:
+      statuses: write
     steps:
       - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
         with:


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/20285483219/job/58258025574#step:9:850

```
2025-12-16 23:05:21 [INFO]   Failed to call GitHub Status API: curl: (22) The requested URL returned error: 403
```

上記を解消するため、CI `pr-super-lint` の `permissions` を修正します。