### PR TITLE
Python, uvアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.9.13-python3.14-bookworm-slim@sha256:84811734dd7ef34300d1a79a32ef0ed551b361ca318241e9a38b1305dea9b425 AS base
+FROM ghcr.io/astral-sh/uv:0.9.17-python3.14-bookworm-slim@sha256:74241aba44a777b228aef38d5d1b411a7405f6ec8faffdc284e24656ea3079b5 AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.9.13"
+required-version = "0.9.17"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hato-bot"
 version = "3.0.5"
 description = "愛嬌のあるBot"
-requires-python = "==3.14.0"
+requires-python = "==3.14.2"
 dependencies = [
     "python-dotenv==1.2.1",
     "requests==2.32.5",

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.0"
+requires-python = "==3.14.2"
 
 [[package]]
 name = "aiohappyeyeballs"


### PR DESCRIPTION
https://github.com/astral-sh/uv/pkgs/container/uv/605525999?tag=0.9.17-python3.14-bookworm-slim

https://github.com/dev-hato/hato-bot/pull/6138 をベースにPythonをアップデートします。
uv 0.9.17はリリースから8日過ぎているので、uvもアップデートします。