### PR TITLE
uvアップデート

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.9.17-python3.14-bookworm-slim@sha256:74241aba44a777b228aef38d5d1b411a7405f6ec8faffdc284e24656ea3079b5 AS base
+FROM ghcr.io/astral-sh/uv:0.9.18-python3.14-bookworm-slim@sha256:6fc12e5d7e7714cbde63532489515adb128632d6ba8c502b52bd30bc064419bb AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.9.17"
+required-version = "0.9.18"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple"


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/20832502173/job/59849933604#step:3:291

```
2026/01/08 21:34:10 ERROR <job_1203872277> error: Required uv version `==0.9.17` does not match the running version `0.9.18`. Update `uv` by running `uv self update 0.9.17`.
```

dependabotがエラーになっているので、uvをアップデートします。