### PR TITLE
renovate・dependabot: pandasをアップデート対象から外す

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,7 @@ updates:
       - dependency-name: mypy
       - dependency-name: numpy
       - dependency-name: click
+      - dependency-name: pandas
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,13 @@
 {
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": ["node-fetch", "sudden-death", "mypy", "numpy", "click", "pandas"],
+  "ignoreDeps": [
+    "node-fetch",
+    "sudden-death",
+    "mypy",
+    "numpy",
+    "click",
+    "pandas"
+  ],
   "packageRules": [
     {
       "matchPackageNames": ["ghcr.io/astral-sh/uv"],

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["github>dev-hato/renovate-config"],
-  "ignoreDeps": ["node-fetch", "sudden-death", "mypy", "numpy", "click"],
+  "ignoreDeps": ["node-fetch", "sudden-death", "mypy", "numpy", "click", "pandas"],
   "packageRules": [
     {
       "matchPackageNames": ["ghcr.io/astral-sh/uv"],

--- a/uv.lock
+++ b/uv.lock
@@ -1517,7 +1517,7 @@ wheels = [
 [[package]]
 name = "sudden-death"
 version = "0.0.1"
-source = { git = "https://github.com/dev-hato/sudden-death?branch=master#53ee7d7e6a619e78fde965ab15ea48316dc8bdf7" }
+source = { git = "https://github.com/dev-hato/sudden-death?branch=master#fc0392a28d0f71b1e77b767db0242469163d65f4" }
 dependencies = [
     { name = "click" },
     { name = "pyperclip" },


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/6299#issuecomment-3812154416

```
Command failed: uv lock --upgrade-package pandas
Using CPython 3.14.2 interpreter at: /opt/containerbase/tools/python/3.14.2/bin/python3
  × No solution found when resolving dependencies for split (markers:
  │ sys_platform == 'win32'):
  ╰─▶ Because pandas==3.0.0 depends on numpy>=2.3.3 and your project depends
      on numpy==2.2.6, we can conclude that your project and pandas==3.0.0
      are incompatible.
      And because your project depends on pandas==3.0.0, we can conclude that
      your project's requirements are unsatisfiable.

      hint: The resolution failed for an environment that is not the current
      one, consider limiting the environments with `tool.uv.environments`.
```

`pandas` と `opencv-python`  は `numpy` に依存していますが、 `pandas` をアップデートすると、これらのパッケージが指定している `numpy` のバージョンがコンフリクトします。
そのため、一旦 `pandas` をrenovateやdependabotによるアップデート対象から外します。