### PR TITLE
super-linterアップデート

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,4 +1,4 @@
 # https://github.com/super-linter/super-linter/blob/6d7d907dcc39a01c96fa8ad337174be89dc525c2/TEMPLATES/.codespellrc
 [codespell]
 check-hidden =
-skip = */package-lock.json,*.log,.git
+skip = */package-lock.json,*.log,.git,*/uv.lock,*/tests/plugins/test_amedastable.json

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+# https://github.com/super-linter/super-linter/blob/6d7d907dcc39a01c96fa8ad337174be89dc525c2/TEMPLATES/.codespellrc
+[codespell]
+check-hidden =
+skip = */package-lock.json,*.log,.git

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: bash "${GITHUB_WORKSPACE}/scripts/pr_test/pr_super_lint/npm_ci.sh"
       - name: Lint files
-        uses: super-linter/super-linter/slim@d5b0a2ab116623730dd094f15ddc1b6b25bf7b99 # v8.3.2
+        uses: super-linter/super-linter/slim@12562e48d7059cf666c43a4ecb0d3b5a2b31bd9e # v8.4.0
         env:
           VALIDATE_ALL_CODEBASE: true
           VALIDATE_SQLFLUFF: false

--- a/.python-lint
+++ b/.python-lint
@@ -46,7 +46,7 @@ confidence=
 # can either give multiple identifiers separated by comma (,) or put this
 # option multiple times (only on the command line, not in the configuration
 # file where it should appear only once).You can also use "--disable=all" to
-# disable everything first and then reenable specific checks. For example, if
+# disable everything first and then re-enable specific checks. For example, if
 # you want to run only the similarities checker, you can use "--disable=all
 # --enable=similarities". If you want to run only the classes checker, but have
 # no Warning level messages displayed, use"--disable=all --enable=classes

--- a/.python-lint
+++ b/.python-lint
@@ -31,10 +31,6 @@ persistent=yes
 # Specify a configuration file.
 #rcfile=
 
-# When enabled, pylint would attempt to guess common misconfiguration and emit
-# user-friendly hints instead of false-positive error messages
-suggestion-mode=yes
-
 # Allow loading of arbitrary C extensions. Extensions are imported into the
 # active Python interpreter and may run arbitrary code.
 unsafe-load-any-extension=no

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,4 +1,4 @@
-// https://github.com/super-linter/super-linter/blob/0d8f7aad449c1dc8ecaf2362684de5d379d2cd7d/TEMPLATES/eslint.config.mjs
+// https://github.com/super-linter/super-linter/blob/644fff4cf8f9c402888e29313139dd6e7cbce40e/TEMPLATES/eslint.config.mjs
 import { defineConfig, globalIgnores } from "eslint/config";
 import n from "eslint-plugin-n";
 import prettier from "eslint-plugin-prettier";
@@ -6,7 +6,7 @@ import globals from "globals";
 import jsoncParser from "jsonc-eslint-parser";
 import typescriptEslint from "@typescript-eslint/eslint-plugin";
 import tsParser from "@typescript-eslint/parser";
-import vueParser from "vue-eslint-parser";
+import pluginVue from "eslint-plugin-vue";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
 import js from "@eslint/js";
@@ -82,7 +82,7 @@ export default defineConfig([
   },
   {
     files: ["**/*.js", "**/*.mjs", "**/*.cjs", "**/*.jsx"],
-    // extends: compat.extends("plugin:react/recommended"),
+    extends: compat.extends("plugin:react/recommended"),
 
     languageOptions: {
       ecmaVersion: "latest",
@@ -102,7 +102,7 @@ export default defineConfig([
     extends: compat.extends(
       "plugin:@typescript-eslint/recommended",
       "plugin:n/recommended",
-      // "plugin:react/recommended",
+      "plugin:react/recommended",
       "prettier",
     ),
 
@@ -120,20 +120,5 @@ export default defineConfig([
       "n/no-missing-import": "off",
     },
   },
-  {
-    files: ["**/*.vue"],
-    extends: compat.extends("plugin:vue/recommended"),
-
-    languageOptions: {
-      parser: vueParser,
-      ecmaVersion: "latest",
-      sourceType: "module",
-
-      parserOptions: {
-        ecmaFeatures: {
-          modules: true,
-        },
-      },
-    },
-  },
+  ...pluginVue.configs["flat/recommended"],
 ]);

--- a/library/clientclass.py
+++ b/library/clientclass.py
@@ -3,6 +3,7 @@
 """
 clientに使うclass
 """
+
 import os
 from abc import ABCMeta, abstractmethod
 

--- a/library/hatomap.py
+++ b/library/hatomap.py
@@ -186,7 +186,7 @@ class RasterTileServer:
         )
 
     def request(self, bbox: WebMercatorPixelBBox) -> np.ndarray:
-        (tl_tilepx, rb_tilepx) = bbox.covered_tiles()
+        tl_tilepx, rb_tilepx = bbox.covered_tiles()
 
         request_urls = []
         for x in range(tl_tilepx.tile.tile_x, rb_tilepx.tile.tile_x + 1):

--- a/library/jma_amesh.py
+++ b/library/jma_amesh.py
@@ -3,6 +3,7 @@
 """
 jma_amesh
 """
+
 import datetime
 import json
 from dataclasses import dataclass

--- a/post_command.py
+++ b/post_command.py
@@ -3,6 +3,7 @@
 """
 localからコマンドを実行するためのスクリプト
 """
+
 import argparse
 
 import requests

--- a/run.py
+++ b/run.py
@@ -85,9 +85,9 @@ def slack_main():
                         if block_element["type"] == "rich_text_section":
                             block_element_elements = block_element["elements"]
                             if (
-                                len(block_element_elements) > 0
-                                and block_element_elements[0]["type"] == "user"
-                                and block_element_elements[0]["user_id"] in authed_users
+                                    len(block_element_elements) > 0
+                                    and block_element_elements[0]["type"] == "user"
+                                    and block_element_elements[0]["user_id"] in authed_users
                             ):
                                 tpe.submit(
                                     analyze.analyze_slack_message(
@@ -177,9 +177,8 @@ async def on_message(message):
             )
 
 
-def main():
-    """メイン関数"""
-
+def setup_logging():
+    """ログ設定を行う"""
     log_format_config = {
         "format": "[%(asctime)s] %(message)s",
         "datefmt": "%Y-%m-%d %H:%M:%S",
@@ -190,83 +189,100 @@ def main():
     logging.getLogger("requests.packages.urllib3.connectionpool").setLevel(
         logging.WARNING
     )
-    logger = logging.getLogger(__name__)
+    return logging.getLogger(__name__)
+
+
+def main():
+    """メイン関数"""
+    logger = setup_logging()
+
     if conf.MODE == "discord":
         discordClient.run(token=conf.DISCORD_API_TOKEN)
     elif conf.MODE == "misskey":
-        misskey_client = Misskey(conf.MISSKEY_DOMAIN, i=conf.MISSKEY_API_TOKEN)
-        misskey_client.timeout = 2
-
-        async def misskey_runner():
-            while True:
-                try:
-                    # pylint: disable=E1101
-                    async with websockets.connect(
-                        "wss://"
-                        + misskey_client.address
-                        + "/streaming"
-                        + "?i="
-                        + misskey_client.token
-                    ) as ws:
-                        await ws.send(
-                            json.dumps(
-                                {
-                                    "type": "connect",
-                                    "body": {"channel": "main", "id": "main"},
-                                }
-                            )
-                        )
-                        while True:
-                            data = json.loads(await ws.recv())
-                            if (
-                                data["type"] == "channel"
-                                and data["body"]["type"] == "mention"
-                            ):
-                                note = data["body"]["body"]
-                                host = note["user"].get("host")
-                                mentions = note.get("mentions")
-                                # FEDERATIONがtrueならばリモートからのメンションにも応答する。
-                                # falseならばローカルのメンションのみに応答する。
-                                if (
-                                    (conf.MISSKEY_FEDERATION == "true")
-                                    or (host is None or host == conf.MISSKEY_DOMAIN)
-                                ) and mentions:
-                                    cred = None
-
-                                    for i in range(10):
-                                        try:
-                                            cred = misskey_client.i()
-                                            break
-                                        except ReadTimeout as e:
-                                            logger.exception(e)
-                                            await asyncio.sleep(1)
-
-                                    if cred is not None and cred["id"] in mentions:
-                                        client = MisskeyClient(misskey_client, note)
-                                        client.add_waiting_reaction()
-                                        try:
-                                            analyze.analyze_message(
-                                                note["text"]
-                                                .replace("\xa0", " ")
-                                                .split(" ", 1)[1]
-                                            )(client)
-                                        except Exception as e:
-                                            logger.exception(e)
-                                            client.post("エラーが発生したっぽ......")
-                except websockets.ConnectionClosedError:
-                    await asyncio.sleep(1)
-
-        while True:
-            try:
-                asyncio.run(misskey_runner())
-            except websockets.exceptions.InvalidStatusCode as e:
-                if e.status_code == 502:
-                    logger.exception(e)
-                    time.sleep(1)
-                else:
-                    raise e
+        run_misskey(logger)
     else:
         slack_main()
+
+
+async def misskey_runner(misskey_client, logger):
+    """Misskeyのメッセージを受信して処理する"""
+    while True:
+        try:
+            # pylint: disable=E1101
+            async with websockets.connect(
+                    "wss://"
+                    + misskey_client.address
+                    + "/streaming"
+                    + "?i="
+                    + misskey_client.token
+            ) as ws:
+                await ws.send(
+                    json.dumps(
+                        {
+                            "type": "connect",
+                            "body": {"channel": "main", "id": "main"},
+                        }
+                    )
+                )
+                while True:
+                    data = json.loads(await ws.recv())
+                    if (
+                            data["type"] == "channel"
+                            and data["body"]["type"] == "mention"
+                    ):
+                        note = data["body"]["body"]
+                        host = note["user"].get("host")
+                        mentions = note.get("mentions")
+                        # FEDERATIONがtrueならばリモートからのメンションにも応答する。
+                        # falseならばローカルのメンションのみに応答する。
+                        if (
+                                (conf.MISSKEY_FEDERATION == "true")
+                                or (host is None or host == conf.MISSKEY_DOMAIN)
+                        ) and mentions:
+                            await handle_misskey_mention(misskey_client, note, logger)
+        except websockets.ConnectionClosedError:
+            await asyncio.sleep(1)
+
+
+async def handle_misskey_mention(misskey_client, note, logger):
+    """Misskeyのメンションを処理する"""
+    cred = None
+
+    for _ in range(10):
+        try:
+            cred = misskey_client.i()
+            break
+        except ReadTimeout as e:
+            logger.exception(e)
+            await asyncio.sleep(1)
+
+    mentions = note.get("mentions")
+    if cred is not None and mentions and cred["id"] in mentions:
+        client = MisskeyClient(misskey_client, note)
+        client.add_waiting_reaction()
+        try:
+            analyze.analyze_message(
+                note["text"].replace("\xa0", " ").split(" ", 1)[1]
+            )(client)
+        except Exception as e:
+            logger.exception(e)
+            client.post("エラーが発生したっぽ......")
+
+
+def run_misskey(logger):
+    """Misskeyモードで起動する"""
+    misskey_client = Misskey(conf.MISSKEY_DOMAIN, i=conf.MISSKEY_API_TOKEN)
+    misskey_client.timeout = 2
+
+    while True:
+        try:
+            asyncio.run(misskey_runner(misskey_client, logger))
+        except websockets.exceptions.InvalidStatusCode as e:
+            if e.status_code == 502:
+                logger.exception(e)
+                time.sleep(1)
+            else:
+                raise e
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -192,16 +192,29 @@ def setup_logging():
     return logging.getLogger(__name__)
 
 
-def main():
-    """メイン関数"""
-    logger = setup_logging()
+async def handle_misskey_mention(misskey_client, note, logger):
+    """Misskeyのメンションを処理する"""
+    cred = None
 
-    if conf.MODE == "discord":
-        discordClient.run(token=conf.DISCORD_API_TOKEN)
-    elif conf.MODE == "misskey":
-        run_misskey(logger)
-    else:
-        slack_main()
+    for _ in range(10):
+        try:
+            cred = misskey_client.i()
+            break
+        except ReadTimeout as e:
+            logger.exception(e)
+            await asyncio.sleep(1)
+
+    mentions = note.get("mentions")
+    if cred is not None and mentions and cred["id"] in mentions:
+        client = MisskeyClient(misskey_client, note)
+        client.add_waiting_reaction()
+        try:
+            analyze.analyze_message(
+                note["text"].replace("\xa0", " ").split(" ", 1)[1]
+            )(client)
+        except Exception as e:
+            logger.exception(e)
+            client.post("エラーが発生したっぽ......")
 
 
 async def misskey_runner(misskey_client, logger):
@@ -244,31 +257,6 @@ async def misskey_runner(misskey_client, logger):
             await asyncio.sleep(1)
 
 
-async def handle_misskey_mention(misskey_client, note, logger):
-    """Misskeyのメンションを処理する"""
-    cred = None
-
-    for _ in range(10):
-        try:
-            cred = misskey_client.i()
-            break
-        except ReadTimeout as e:
-            logger.exception(e)
-            await asyncio.sleep(1)
-
-    mentions = note.get("mentions")
-    if cred is not None and mentions and cred["id"] in mentions:
-        client = MisskeyClient(misskey_client, note)
-        client.add_waiting_reaction()
-        try:
-            analyze.analyze_message(
-                note["text"].replace("\xa0", " ").split(" ", 1)[1]
-            )(client)
-        except Exception as e:
-            logger.exception(e)
-            client.post("エラーが発生したっぽ......")
-
-
 def run_misskey(logger):
     """Misskeyモードで起動する"""
     misskey_client = Misskey(conf.MISSKEY_DOMAIN, i=conf.MISSKEY_API_TOKEN)
@@ -283,6 +271,18 @@ def run_misskey(logger):
                 time.sleep(1)
             else:
                 raise e
+
+
+def main():
+    """メイン関数"""
+    logger = setup_logging()
+
+    if conf.MODE == "discord":
+        discordClient.run(token=conf.DISCORD_API_TOKEN)
+    elif conf.MODE == "misskey":
+        run_misskey(logger)
+    else:
+        slack_main()
 
 
 if __name__ == "__main__":

--- a/run.py
+++ b/run.py
@@ -85,9 +85,9 @@ def slack_main():
                         if block_element["type"] == "rich_text_section":
                             block_element_elements = block_element["elements"]
                             if (
-                                    len(block_element_elements) > 0
-                                    and block_element_elements[0]["type"] == "user"
-                                    and block_element_elements[0]["user_id"] in authed_users
+                                len(block_element_elements) > 0
+                                and block_element_elements[0]["type"] == "user"
+                                and block_element_elements[0]["user_id"] in authed_users
                             ):
                                 tpe.submit(
                                     analyze.analyze_slack_message(
@@ -209,9 +209,9 @@ async def handle_misskey_mention(misskey_client, note, logger):
         client = MisskeyClient(misskey_client, note)
         client.add_waiting_reaction()
         try:
-            analyze.analyze_message(
-                note["text"].replace("\xa0", " ").split(" ", 1)[1]
-            )(client)
+            analyze.analyze_message(note["text"].replace("\xa0", " ").split(" ", 1)[1])(
+                client
+            )
         except Exception as e:
             logger.exception(e)
             client.post("エラーが発生したっぽ......")
@@ -223,11 +223,11 @@ async def misskey_runner(misskey_client, logger):
         try:
             # pylint: disable=E1101
             async with websockets.connect(
-                    "wss://"
-                    + misskey_client.address
-                    + "/streaming"
-                    + "?i="
-                    + misskey_client.token
+                "wss://"
+                + misskey_client.address
+                + "/streaming"
+                + "?i="
+                + misskey_client.token
             ) as ws:
                 await ws.send(
                     json.dumps(
@@ -239,18 +239,15 @@ async def misskey_runner(misskey_client, logger):
                 )
                 while True:
                     data = json.loads(await ws.recv())
-                    if (
-                            data["type"] == "channel"
-                            and data["body"]["type"] == "mention"
-                    ):
+                    if data["type"] == "channel" and data["body"]["type"] == "mention":
                         note = data["body"]["body"]
                         host = note["user"].get("host")
                         mentions = note.get("mentions")
                         # FEDERATIONがtrueならばリモートからのメンションにも応答する。
                         # falseならばローカルのメンションのみに応答する。
                         if (
-                                (conf.MISSKEY_FEDERATION == "true")
-                                or (host is None or host == conf.MISSKEY_DOMAIN)
+                            (conf.MISSKEY_FEDERATION == "true")
+                            or (host is None or host == conf.MISSKEY_DOMAIN)
                         ) and mentions:
                             await handle_misskey_mention(misskey_client, note, logger)
         except websockets.ConnectionClosedError:

--- a/run.py
+++ b/run.py
@@ -3,6 +3,7 @@
 """
 BotのMain関数
 """
+
 import asyncio
 import json
 import logging

--- a/run.py
+++ b/run.py
@@ -262,8 +262,8 @@ def run_misskey(logger):
     while True:
         try:
             asyncio.run(misskey_runner(misskey_client, logger))
-        except websockets.exceptions.InvalidStatusCode as e:
-            if e.status_code == 502:
+        except websockets.exceptions.InvalidStatus as e:
+            if e.response.status_code == 502:
                 logger.exception(e)
                 time.sleep(1)
             else:

--- a/tests/library/test_hukidasi.py
+++ b/tests/library/test_hukidasi.py
@@ -19,12 +19,10 @@ class TestHukidashiGenerator(unittest.TestCase):
         """
         self.assertEqual(
             generator("Hello, pegion!"),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
         ＿人人人人人人人人人＿
         ＞  Hello, pegion!  ＜
-        ￣^Y^Y^Y^Y^Y^Y^Y^Y^Y￣"""
-            ),
+        ￣^Y^Y^Y^Y^Y^Y^Y^Y^Y￣"""),
         )
 
     def test_normal_one_line_zenkaku(self):
@@ -33,12 +31,10 @@ class TestHukidashiGenerator(unittest.TestCase):
         """
         self.assertEqual(
             generator("言うことを聞け"),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
         ＿人人人人人人人人人＿
         ＞  言うことを聞け  ＜
-        ￣^Y^Y^Y^Y^Y^Y^Y^Y^Y￣"""
-            ),
+        ￣^Y^Y^Y^Y^Y^Y^Y^Y^Y￣"""),
         )
 
     def test_normal_multiline(self):

--- a/tests/library/test_hukidasi.py
+++ b/tests/library/test_hukidasi.py
@@ -43,11 +43,9 @@ class TestHukidashiGenerator(unittest.TestCase):
         """
         self.assertEqual(
             generator("そして、\n鳩は唐揚げになる"),
-            textwrap.dedent(
-                """\
+            textwrap.dedent("""\
         ＿人人人人人人人人人人＿
         ＞      そして、      ＜
         ＞  鳩は唐揚げになる  ＜
-        ￣^Y^Y^Y^Y^Y^Y^Y^Y^Y^Y￣"""
-            ),
+        ￣^Y^Y^Y^Y^Y^Y^Y^Y^Y^Y￣"""),
         )


### PR DESCRIPTION
## 概要
https://github.com/dev-hato/hato-bot/pull/6327 をベースにsuper-linterをアップデートします。
また、それに伴うlint指摘事項を修正します。

## 変更内容

### super-linter関連
- super-linter/super-linterをv8.4.0にアップデート
- eslint.config.mjsを新しいテンプレートに合わせて更新（vue-eslint-parserからeslint-plugin-vueへの移行、react pluginの有効化）
- `.codespellrc`を追加し、日本語地名のローマ字表記（Dake, Toi等）やパッケージ名（astroid）の誤検知を除外

### pylint関連
- `.python-lint`から廃止された`suggestion-mode`オプションを削除
- コメント内のtypo修正（`reenable` → `re-enable`）

### コード修正
- `run.py`: main関数の複雑度を下げるためにリファクタリング（`setup_logging`, `handle_misskey_mention`, `misskey_runner`, `run_misskey`に分割）
- `run.py`: websocketsの例外クラスを`InvalidStatusCode`から`InvalidStatus`に更新
- blackによるフォーマット修正（docstring後の空行追加、`textwrap.dedent`の引数整形、タプルアンパックの括弧削除）