### PR TITLE
uvのバージョンをDependabotがサポートするバージョンに合わせるようにする

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.9.29-python3.14-bookworm-slim@sha256:b943ae41018255b8e3ddb560a22fa1f16cdcf0c92760a68c6161d21a837edf56 AS base
+FROM ghcr.io/astral-sh/uv:0.9.18-python3.14-bookworm-slim@sha256:6fc12e5d7e7714cbde63532489515adb128632d6ba8c502b52bd30bc064419bb AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.9.29"
+required-version = "0.9.18"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple"

--- a/renovate.json
+++ b/renovate.json
@@ -6,13 +6,10 @@
     "mypy",
     "numpy",
     "click",
-    "pandas"
+    "pandas",
+    "ghcr.io/astral-sh/uv"
   ],
   "packageRules": [
-    {
-      "matchPackageNames": ["ghcr.io/astral-sh/uv"],
-      "prPriority": 10
-    },
     {
       "groupName": "slack",
       "matchPackageNames": ["slack-bolt", "slack-sdk"]

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 set -e
 
-uv_version=$(grep ghcr.io/astral-sh/uv: Dockerfile | sed -e 's!FROM ghcr.io/astral-sh/uv:\([0-9.]*\)-.*!\1!g')
+uv_version=$(docker run --rm ghcr.io/dependabot/dependabot-updater-uv uv --version | sed -e 's/^uv //g')
 sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml
+image_name=ghcr.io/astral-sh/uv
+image_tag=$image_name:$uv_version-python3.14-bookworm-slim
+docker pull "$image_tag"
+sed -i -e "s?^FROM $image_name:.[^ ]* ?FROM $image_tag$(docker inspect "$image_tag" | yq '.[0].RepoDigests[0]' | sed -e "s:^$image_name::g") ?g" Dockerfile


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/security/dependabot/92 で `Dependabot does not support your uv version` エラーが発生していたため、uvのバージョン取得元をDependabotのuv updaterコンテナに変更し、Dependabotがサポートするバージョンと一致させるようにします。
また、Renovateによるuvの自動更新がバージョン不整合の原因となるため無効化しています。
https://github.com/dev-hato/hato-bot/pull/6353 を前提としています。