### PR TITLE
fix: multiprocessing.Pool(fork)をThreadPoolExecutorに置き換える

### DIFF
--- a/library/hatomap.py
+++ b/library/hatomap.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
 import math
-import multiprocessing
 import random
 import string
+from concurrent.futures import ThreadPoolExecutor
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
@@ -196,8 +196,8 @@ class RasterTileServer:
                         {"x": x, "y": y, "z": bbox.zoom}
                     )
                 )
-        with multiprocessing.get_context(method="fork").Pool(16) as p:
-            imgs = list(p.imap(self._get_image_content, request_urls))
+        with ThreadPoolExecutor(max_workers=16) as executor:
+            imgs = list(executor.map(self._get_image_content, request_urls))
 
         tile_width_cnt = rb_tilepx.tile.tile_x + 1 - tl_tilepx.tile.tile_x
         tile_height_cnt = rb_tilepx.tile.tile_y + 1 - tl_tilepx.tile.tile_y

--- a/library/hatomap.py
+++ b/library/hatomap.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 import math
 import random
 import string
-from concurrent.futures import ThreadPoolExecutor
 from abc import ABCMeta, abstractmethod
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from typing import List, Optional, Tuple
 


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/blob/982607283a2f8356d3fdcb2acbb8cbc3b1b0a5df/library/hatomap.py#L179-L181

macOSでのpytest実行時に、マルチスレッドプロセス (pytest) からfork()した後、上記でrequestsがプロキシ設定を取得しようとするとSIGSEGVが発生する問題を修正する。
                                                                                        
ThreadPoolExecutorはfork()しないためこのクラッシュが発生せず、またスレッドは同プロセスのメモリを共有するためrequests_mockもそのまま有効になる。

HTTPリクエストではI/O待機中にGILが解放されスレッドでも実質並列に実行できるため、multiprocessing.Poolより適切であり、結果として #5926 でforkを明示していた問題も根本から解消される。