### PR TITLE
puremagicアップデート

### DIFF
--- a/plugins/hato.py
+++ b/plugins/hato.py
@@ -182,14 +182,12 @@ def earth_quake(client: BaseClient):
                 map_img.save(map_file, format="PNG")
 
                 filename = ["map"]
-                ext = puremagic.what(map_file.name)
+                ext = puremagic.from_file(map_file.name)
 
                 if ext:
                     filename.append(ext)
 
-                client.upload(
-                    file=map_file.name, filename=os.path.extsep.join(filename)
-                )
+                client.upload(file=map_file.name, filename="".join(filename))
 
 
 @action("textlint")
@@ -282,14 +280,12 @@ def amesh(client: BaseClient, place: str):
         amesh_img.save(weather_map_file, format="PNG")
 
         filename = ["amesh"]
-        ext = puremagic.what(weather_map_file.name)
+        ext = puremagic.from_file(weather_map_file.name)
 
         if ext:
             filename.append(ext)
 
-        client.upload(
-            file=weather_map_file.name, filename=os.path.extsep.join(filename)
-        )
+        client.upload(file=weather_map_file.name, filename="".join(filename))
 
 
 @action("amedas", with_client=True)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
     "markupsafe==3.0.3",
     "numpy==2.2.6",
     "emoji==2.15.0",
-    "puremagic==1.30",
+    "puremagic==2.0.0",
     "audioop-lts==0.2.2",
     "psycopg[binary,pool]==3.3.3",
     "sudden-death==0.0.1",

--- a/uv.lock
+++ b/uv.lock
@@ -550,7 +550,7 @@ requires-dist = [
     { name = "pandas", specifier = "==2.3.3" },
     { name = "pillow", specifier = ">=7.1.2" },
     { name = "psycopg", extras = ["binary", "pool"], specifier = "==3.3.3" },
-    { name = "puremagic", specifier = "==1.30" },
+    { name = "puremagic", specifier = "==2.0.0" },
     { name = "python-dotenv", specifier = "==1.2.1" },
     { name = "requests", specifier = "==2.32.5" },
     { name = "slack-bolt", specifier = "==1.27.0" },
@@ -1184,11 +1184,11 @@ wheels = [
 
 [[package]]
 name = "puremagic"
-version = "1.30"
+version = "2.0.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/dd/7f/9998706bc516bdd664ccf929a1da6c6e5ee06e48f723ce45aae7cf3ff36e/puremagic-1.30.tar.gz", hash = "sha256:f9ff7ac157d54e9cf3bff1addfd97233548e75e685282d84ae11e7ffee1614c9", size = 314785, upload-time = "2025-07-04T18:48:36.061Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/df/a2ee3bbf55f036acb9725b35732e3a785cb06f5c5b9fe47bde8c05ab873a/puremagic-2.0.0.tar.gz", hash = "sha256:224fe42b6b3467276a45914e12b5f40905dea0e87963adbe5289667e7c607851", size = 1119578, upload-time = "2026-02-20T13:37:53.262Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/91/ed/1e347d85d05b37a8b9a039ca832e5747e1e5248d0bd66042783ef48b4a37/puremagic-1.30-py3-none-any.whl", hash = "sha256:5eeeb2dd86f335b9cfe8e205346612197af3500c6872dffebf26929f56e9d3c1", size = 43304, upload-time = "2025-07-04T18:48:34.801Z" },
+    { url = "https://files.pythonhosted.org/packages/79/03/f4a28d560494cfdf6a619c61ae5664390fac4f4b640df82e304d48f457e3/puremagic-2.0.0-py3-none-any.whl", hash = "sha256:c86aee5c15d6a346e72c5b964f1d930d42bc7dc058afdf4ac63ab92f26086aaf", size = 65924, upload-time = "2026-02-20T13:37:51.992Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/6442 を元にpuremagicをアップデートします。
合わせて以下のように修正します。

- puremagic.what() を puremagic.from_file() に変更（v2 API対応）
- puremagic v2 の from_file() はドット付き拡張子（例: '.png'）を返すため、os.path.extsep.join() で結合すると 'amesh..png' になる問題を修正。"".join() を使うことで正しく 'amesh.png' として結合されるようにした。
- client.upload() の呼び出しを1行に整形（Black対応）