### PR TITLE
fix: GHCR APIでDebian slimタグを動的に取得

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -36,6 +36,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh"
         env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           HEAD_REF: ${{github.head_ref || github.event.release.tag_name}}
       - uses: dev-hato/actions-diff-pr-management@b446497d139ed3eadc62ec1dd90dd27960ad1a0c # v2.2.4
         with:

--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.9.18-python3.14-bookworm-slim@sha256:6fc12e5d7e7714cbde63532489515adb128632d6ba8c502b52bd30bc064419bb AS base
+FROM ghcr.io/astral-sh/uv:0.10.9-python3.14-trixie-slim@sha256:009e0a24546776dc561c4058a3e643839a16a59b61469dd9ebfb620e79e8ac9a AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.9.18"
+required-version = "0.10.9"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple"

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -3,39 +3,16 @@ set -e
 
 uv_version=$(docker run --rm ghcr.io/dependabot/dependabot-updater-uv uv --version | sed -e 's/^uv //g')
 sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml
-image_name=ghcr.io/astral-sh/uv
-token=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:astral-sh/uv:pull" | jq -r .token)
-image_tag=""
-last="$uv_version"
+match=$(gh api --paginate /orgs/astral-sh/packages/container/uv/versions --jq '.[].metadata.container.tags[]' |
+  grep -m 1 -E "^${uv_version}-python3\.14-.+-slim$")
 
-while [ -z "$image_tag" ]; do
-  tags=$(curl -s "https://ghcr.io/v2/astral-sh/uv/tags/list?n=100&last=$last" \
-    -H "Authorization: Bearer $token" | jq -r '.tags[]' 2>/dev/null)
-
-  if [ -z "$tags" ]; then
-    break
-  fi
-
-  match=$(echo "$tags" | grep -m 1 -E "^${uv_version}-python3\.14-.+-slim$")
-
-  if [ -n "$match" ]; then
-    image_tag=$image_name:$match
-    break
-  fi
-
-  # このバージョンのタグを過ぎたら終了
-  if ! echo "$tags" | grep -q "^${uv_version}-"; then
-    break
-  fi
-
-  last=$(echo "$tags" | tail -1)
-done
-
-if [ -z "$image_tag" ]; then
+if [ -z "$match" ]; then
   echo "Error: uv $uv_version に対応するDebian slimタグが見つかりません。" >&2
   echo "利用可能なタグ: https://github.com/astral-sh/uv/pkgs/container/uv" >&2
   exit 1
 fi
 
+image_name=ghcr.io/astral-sh/uv
+image_tag=$image_name:$match
 docker pull "$image_tag"
 sed -i -e "s?^FROM $image_name:.[^ ]* ?FROM $image_tag$(docker inspect "$image_tag" | yq '.[0].RepoDigests[0]' | sed -e "s:^$image_name::g") ?g" Dockerfile

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -4,6 +4,38 @@ set -e
 uv_version=$(docker run --rm ghcr.io/dependabot/dependabot-updater-uv uv --version | sed -e 's/^uv //g')
 sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml
 image_name=ghcr.io/astral-sh/uv
-image_tag=$image_name:$uv_version-python3.14-bookworm-slim
+token=$(curl -s "https://ghcr.io/token?service=ghcr.io&scope=repository:astral-sh/uv:pull" | jq -r .token)
+image_tag=""
+last="$uv_version"
+
+while [ -z "$image_tag" ]; do
+  tags=$(curl -s "https://ghcr.io/v2/astral-sh/uv/tags/list?n=100&last=$last" \
+    -H "Authorization: Bearer $token" | jq -r '.tags[]' 2>/dev/null)
+
+  if [ -z "$tags" ]; then
+    break
+  fi
+
+  match=$(echo "$tags" | grep -m 1 -E "^${uv_version}-python3\.14-.+-slim$")
+
+  if [ -n "$match" ]; then
+    image_tag=$image_name:$match
+    break
+  fi
+
+  # このバージョンのタグを過ぎたら終了
+  if ! echo "$tags" | grep -q "^${uv_version}-"; then
+    break
+  fi
+
+  last=$(echo "$tags" | tail -1)
+done
+
+if [ -z "$image_tag" ]; then
+  echo "Error: uv $uv_version に対応するDebian slimタグが見つかりません。" >&2
+  echo "利用可能なタグ: https://github.com/astral-sh/uv/pkgs/container/uv" >&2
+  exit 1
+fi
+
 docker pull "$image_tag"
 sed -i -e "s?^FROM $image_name:.[^ ]* ?FROM $image_tag$(docker inspect "$image_tag" | yq '.[0].RepoDigests[0]' | sed -e "s:^$image_name::g") ?g" Dockerfile


### PR DESCRIPTION
Debian のコードネームをハードコードする代わりに、GHCR tags API で `$uv_version-python3.14-*-slim` にマッチするタグを動的に検索する。
これにより将来のDebianバージョン変更にも自動で追従できる。