### PR TITLE
CI update-uv-version: gh apiでDebian slimタグを動的に取得

### DIFF
--- a/.github/workflows/deploy-hato-bot.yml
+++ b/.github/workflows/deploy-hato-bot.yml
@@ -23,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      packages: read
       pull-requests: write
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -35,6 +36,7 @@ jobs:
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: bash "${GITHUB_WORKSPACE}/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh"
         env:
+          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
           HEAD_REF: ${{github.head_ref || github.event.release.tag_name}}
       - uses: dev-hato/actions-diff-pr-management@b446497d139ed3eadc62ec1dd90dd27960ad1a0c # v2.2.4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.9.18-python3.14-bookworm-slim@sha256:6fc12e5d7e7714cbde63532489515adb128632d6ba8c502b52bd30bc064419bb AS base
+FROM ghcr.io/astral-sh/uv:0.10.9-python3.14-trixie-slim@sha256:009e0a24546776dc561c4058a3e643839a16a59b61469dd9ebfb620e79e8ac9a AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 name = "hato-bot"
 version = "3.0.5"
 description = "愛嬌のあるBot"
-requires-python = "==3.14.2"
+requires-python = "==3.14.3"
 dependencies = [
     "python-dotenv==1.2.1",
     "requests==2.32.5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.9.18"
+required-version = "0.10.9"
 [[tool.uv.index]]
 name = "pypi"
 url = "https://pypi.org/simple"

--- a/scripts/deploy_hato_bot/dockle/run_dockle.sh
+++ b/scripts/deploy_hato_bot/dockle/run_dockle.sh
@@ -15,7 +15,7 @@ for image_name in $(docker compose images | awk 'OFS=":" {print $2,$3}' | tail -
 	if [[ "${image_name}" =~ "postgres" ]]; then
 		cmd+="-ak key "
 	elif [[ "${image_name}" =~ "hato-bot" ]]; then
-		cmd+="-i CIS-DI-0006 -af settings.py "
+		cmd+="-i CIS-DI-0006 -i DKL-DI-0005 -af settings.py "
 	fi
 
 	cmd+="${image_name}"

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -4,12 +4,12 @@ set -e
 uv_version=$(docker run --rm ghcr.io/dependabot/dependabot-updater-uv uv --version | sed -e 's/^uv //g')
 sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml
 match=$(gh api --paginate /orgs/astral-sh/packages/container/uv/versions --jq '.[].metadata.container.tags[]' |
-  grep -m 1 -E "^${uv_version}-python3\.14-.+-slim$")
+	grep -m 1 -E "^${uv_version}-python3\.14-.+-slim$")
 
 if [ -z "$match" ]; then
-  echo "Error: uv $uv_version に対応するDebian slimタグが見つかりません。" >&2
-  echo "利用可能なタグ: https://github.com/astral-sh/uv/pkgs/container/uv" >&2
-  exit 1
+	echo "Error: uv $uv_version に対応するDebian slimタグが見つかりません。" >&2
+	echo "利用可能なタグ: https://github.com/astral-sh/uv/pkgs/container/uv" >&2
+	exit 1
 fi
 
 image_name=ghcr.io/astral-sh/uv

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -3,7 +3,16 @@ set -e
 
 uv_version=$(docker run --rm ghcr.io/dependabot/dependabot-updater-uv uv --version | sed -e 's/^uv //g')
 sed -i -e "s/required-version = .*/required-version = \"$uv_version\"/g" pyproject.toml
+match=$(gh api --paginate /orgs/astral-sh/packages/container/uv/versions --jq '.[].metadata.container.tags[]' |
+  grep -m 1 -E "^${uv_version}-python3\.14-.+-slim$")
+
+if [ -z "$match" ]; then
+  echo "Error: uv $uv_version に対応するDebian slimタグが見つかりません。" >&2
+  echo "利用可能なタグ: https://github.com/astral-sh/uv/pkgs/container/uv" >&2
+  exit 1
+fi
+
 image_name=ghcr.io/astral-sh/uv
-image_tag=$image_name:$uv_version-python3.14-bookworm-slim
+image_tag=$image_name:$match
 docker pull "$image_tag"
 sed -i -e "s?^FROM $image_name:.[^ ]* ?FROM $image_tag$(docker inspect "$image_tag" | yq '.[0].RepoDigests[0]' | sed -e "s:^$image_name::g") ?g" Dockerfile

--- a/uv.lock
+++ b/uv.lock
@@ -1,6 +1,6 @@
 version = 1
 revision = 3
-requires-python = "==3.14.2"
+requires-python = "==3.14.3"
 
 [[package]]
 name = "aiohappyeyeballs"

--- a/uv.lock
+++ b/uv.lock
@@ -1521,7 +1521,7 @@ wheels = [
 [[package]]
 name = "sudden-death"
 version = "0.0.1"
-source = { git = "https://github.com/dev-hato/sudden-death?branch=master#9a1583968ddb9486334ca18196a6327fe85a4792" }
+source = { git = "https://github.com/dev-hato/sudden-death?branch=master#b783bd4bacfbb15b1a736818d56ea4330faf0f0f" }
 dependencies = [
     { name = "click" },
     { name = "pyperclip" },


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/22908831611/job/66540320608?pr=6471

```
Error response from daemon: manifest unknown
```

uv 0.10.0でghcr.io/astral-sh/uvのbookworm-slimタグが廃止されたため ( astral-sh/uv#17755 )、上記のエラーが発生しています。
こういったケースに対応できるよう、gh api --paginateで `$uv_version-python3.14-*-slim`にマッチするイメージタグを動的に検索する形にします。