### PR TITLE
CI pr-update-gitleaks: PR close時に失敗しないようにする

### DIFF
--- a/.github/workflows/pr-update-gitleaks.yml
+++ b/.github/workflows/pr-update-gitleaks.yml
@@ -32,6 +32,7 @@ jobs:
           cache: npm
           node-version-file: package.json
       - run: npm install -g "$(yq -r '.packageManager' package.json)"
+        if: github.event_name != 'pull_request' || github.event.action != 'closed'
       - name: Install packages
         if: github.event_name != 'pull_request' || github.event.action != 'closed'
         run: npm ci


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/24277099526/job/70892823547

PR close時にCI `pr-update-gitleaks` の意図しないstepが実行されて失敗しているので、実行されないようにします。