### PR TITLE
openaiアップデート

### DIFF
--- a/library/chat_gpt.py
+++ b/library/chat_gpt.py
@@ -4,10 +4,22 @@ from openai import OpenAI, RateLimitError
 
 import slackbot_settings as conf
 
-client = OpenAI(api_key=conf.OPENAI_API_KEY)
+_client: Optional[OpenAI] = None
+
+
+def _get_client() -> OpenAI:
+    global _client
+    client = _client
+
+    if client is None:
+        client = OpenAI(api_key=conf.OPENAI_API_KEY)
+        _client = client
+
+    return client
 
 
 def chat_gpt(message: str) -> Optional[str]:
+    client = _get_client()
     try:
         result = client.chat.completions.create(
             model="gpt-3.5-turbo",
@@ -29,7 +41,7 @@ def chat_gpt(message: str) -> Optional[str]:
 
 
 def image_create(message: str) -> Optional[str]:
-    response = client.images.generate(prompt=message, n=1, size="512x512")
+    response = _get_client().images.generate(prompt=message, n=1, size="512x512")
 
     if response.data is None:
         return response.data

--- a/library/chat_gpt.py
+++ b/library/chat_gpt.py
@@ -19,9 +19,8 @@ def _get_client() -> OpenAI:
 
 
 def chat_gpt(message: str) -> Optional[str]:
-    client = _get_client()
     try:
-        result = client.chat.completions.create(
+        result = _get_client().chat.completions.create(
             model="gpt-3.5-turbo",
             messages=[
                 {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "gitpython==3.1.50",
     "pandas==2.3.3",
     "matplotlib==3.10.9",
-    "openai==2.33.0",
+    "openai==2.36.0",
     "discord.py==2.7.1",
     "misskey.py==4.1.0",
     "websockets==16.0",

--- a/uv.lock
+++ b/uv.lock
@@ -571,7 +571,7 @@ requires-dist = [
     { name = "matplotlib", specifier = "==3.10.9" },
     { name = "misskey-py", specifier = "==4.1.0" },
     { name = "numpy", specifier = "==2.2.6" },
-    { name = "openai", specifier = "==2.33.0" },
+    { name = "openai", specifier = "==2.36.0" },
     { name = "opencv-python", specifier = "==4.13.0.92" },
     { name = "pandas", specifier = "==2.3.3" },
     { name = "pillow", specifier = ">=7.1.2" },
@@ -978,7 +978,7 @@ sdist = { url = "https://files.pythonhosted.org/packages/76/21/7d2a95e4bba9dc13d
 
 [[package]]
 name = "openai"
-version = "2.33.0"
+version = "2.36.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -990,9 +990,9 @@ dependencies = [
     { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f0/ee/d056c82f63c05f06baac0cffb4a90952d8274f90c49dfe244f20497b9bbd/openai-2.33.0.tar.gz", hash = "sha256:f850c435e2a4685bba3295bd54912dd26315d9c1b7733068186134d6e0599f9a", size = 693254, upload-time = "2026-04-28T14:04:42.428Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/a1/4d5e84cf51720fc1526cc49e10ac1961abcccb55b0efb3d970db1e9a2728/openai-2.36.0.tar.gz", hash = "sha256:139dea0edd2f1b30c33d46ae1a6929e03906254140318e4608e98fe8c566f2e7", size = 753003, upload-time = "2026-05-07T17:33:17.075Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/7d/32/37734d769bc8b42e4938785313cc05aade6cb0fa72479d3220a0d61a4e78/openai-2.33.0-py3-none-any.whl", hash = "sha256:03ac37d70e8c9e3a8124214e3afa785e2cbc12e627fbd98177a086ef2fd87ad5", size = 1162695, upload-time = "2026-04-28T14:04:40.482Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1c/5d43735b2553baae2a5e899dcbcd0670a86930d993184d72ca909bf11c9b/openai-2.36.0-py3-none-any.whl", hash = "sha256:143f6194b548dbc2c921af1f1b03b9f14c85fed8a75b5b516f5bcc11a2a50c63", size = 1302361, upload-time = "2026-05-07T17:33:15.063Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/pull/6680 をベースにopenaiをアップデートします。

https://github.com/dev-hato/hato-bot/actions/runs/25955484092/job/76301272722?pr=6680

```
======================================================================
ERROR: tests.plugins.test_analyze (unittest.loader._FailedTest.tests.plugins.test_analyze)
----------------------------------------------------------------------
ImportError: Failed to import test module: tests.plugins.test_analyze
Traceback (most recent call last):
  File "/home/runner/work/_temp/uv-python-dir/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/unittest/loader.py", line 426, in _find_test_path
    module = self._get_module_from_name(name)
  File "/home/runner/work/_temp/uv-python-dir/cpython-3.14.4-linux-x86_64-gnu/lib/python3.14/unittest/loader.py", line 367, in _get_module_from_name
    __import__(name)
    ~~~~~~~~~~^^^^^^
  File "/home/runner/work/hato-bot/hato-bot/tests/plugins/test_analyze.py", line 7, in <module>
    from plugins import hato
  File "/home/runner/work/hato-bot/hato-bot/plugins/hato.py", line 22, in <module>
    from library.chat_gpt import chat_gpt, image_create
  File "/home/runner/work/hato-bot/hato-bot/library/chat_gpt.py", line 7, in <module>
    client = OpenAI(api_key=conf.OPENAI_API_KEY)
  File "/home/runner/work/hato-bot/hato-bot/.venv/lib/python3.14/site-packages/openai/_client.py", line 194, in __init__
    raise OpenAIError(
        "Missing credentials. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable."
    )
openai.OpenAIError: Missing credentials. Please pass an `api_key`, `workload_identity`, `admin_api_key`, or set the `OPENAI_API_KEY` or `OPENAI_ADMIN_KEY` environment variable.
```

OpenAIのクライアントが初期化されることでテストが失敗しているので、遅延初期化するようにしています。