### PR TITLE
CI update-uv-version: ghcr.io/dependabot/dependabot-updater-uvのイメージ取得処理修正

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:0.11.12-python3.14-trixie-slim@sha256:4ec58725d2e4acfb8eccf923f9c3201f858f8ef6414deeeb8fe5a6ecc2fa5331 AS base
+FROM ghcr.io/astral-sh/uv:0.11.8-python3.14-trixie-slim@sha256:b3b7ad909281e78785cbc676c8c8b45816c31638b36dc0cbd9e51725f2f0399c AS base
 
 # バージョン情報に表示する commit hash を埋め込む
 FROM base AS commit-hash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ dev = [
 ]
 
 [tool.uv]
-required-version = "0.11.12"
+required-version = "0.11.8"
 [[tool.uv.index]]
 url = "https://pypi.flatt.tech/simple/"
 default = true

--- a/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
+++ b/scripts/deploy_hato_bot/update_uv_version/get_uv_version.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-image='ghcr.io/dependabot/dependabot-updater-uv:latest'
+image=$(curl https://raw.githubusercontent.com/github/dependabot-action/refs/heads/main/docker/containers.json | yq .uv)
 
 echo "Pulling $image" >&2
 docker pull "$image" >&2


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/actions/runs/30180996750/job/89737350775

```
+------------------------------------------------------------------------------+
|                        Dependencies failed to update                         |
+------------+----------------------------+------------------------------------+
| Dependency | Error Type                 | Error Details                      |
+------------+----------------------------+------------------------------------+
| gitpython  | tool_version_not_supported | {                                  |
|            |                            |   "tool-name": "uv",               |
|            |                            |   "detected-version": "==0.11.12", |
|            |                            |   "supported-versions": "0.11.8"   |
|            |                            | }                                  |
+------------+----------------------------+------------------------------------+
```

https://github.com/github/dependabot-action/blob/394dae3180bd1a1f89d4b83ca9bd57210627c953/src/docker-tags.ts#L6-L10
https://github.com/github/dependabot-action/blob/394dae3180bd1a1f89d4b83ca9bd57210627c953/docker/containers.json#L25

Dependabotでは上記のように https://github.com/github/dependabot-action/blob/26b324bb5b1ef5dda6f339afddd9ad7ab59b2452/docker/containers.json  を参照することで ghcr.io/dependabot/dependabot-updater-uv のイメージタグを取得しているようなので、CI update-uv-versionでの ghcr.io/dependabot/dependabot-updater-uv のイメージ取得処理をそれに合わせます。