### PR TITLE
dependabot: uvをアップデート対象から除外

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,6 +21,7 @@ updates:
       - dependency-name: python
         versions:
           - 3.11.0b1-slim-bullseye
+      - dependency-name: astral-sh/uv
     open-pull-requests-limit: 1
     cooldown:
       default-days: 7


### PR DESCRIPTION
https://github.com/dev-hato/hato-bot/blob/05982964dc5d8579c394b7364828f7e1437b6a99/renovate.json#L3-L11
上記と同様にuvをdependabotによるアップデート対象から除外します。